### PR TITLE
Add DLC loading guide and update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,14 @@ d3d12_low_latency_swap_chain = true
 d3d12_max_frame_latency = 1
 ```
 
-## Modding Docs
+## Documentation & Modding Docs
 
+- [Asset Extraction Walkthrough](docs/ac6_asset_extraction_walkthrough.txt)
+- [Audio Extraction Walkthrough](docs/ac6_audio_extraction_walkthrough.txt)
+- [DLC Loading Guide](docs/ac6_dlc_loading_guide.txt)
 - [Texture Swap Modding Guide](docs/TEXTURE_SWAP_MODDING_GUIDE.txt)
 - [Texture Swap Reference](docs/TEXTURE_SWAPS.txt)
+
 
 ## Runtime Defaults
 

--- a/docs/ac6_dlc_loading_guide.txt
+++ b/docs/ac6_dlc_loading_guide.txt
@@ -101,13 +101,20 @@ your ac6recomp folder.
 4. Enabling DLC Licenses
 --------------------------------------------------------------------------------
 
-To bypass license checks for the copied DLC files, you must configure the 
-global license mask cvar in the game's configuration file.
+By default, recent versions of the PC port automatically configure the global 
+license mask cvar to enable all licenses (defaulting to 4294967295 / 0xFFFFFFFF). 
+This means you do not need to manually configure the license mask in your TOML 
+file for standard DLC to work out of the box.
 
-1. Open "ac6recomp.toml" in your game root directory.
-2. Add or modify the "license_mask" setting to enable all licenses:
+However, if you want to explicitly configure or override this behavior, you can 
+manage it via "ac6recomp.toml" in your game root directory:
 
-    license_mask = 4294967295
+1. Open "ac6recomp.toml".
+2. Set the "license_mask" to your preferred value:
+   
+   - To unlock all licenses (default):
+     license_mask = 4294967295
+     
+   - To enforce strict, header-accurate checks:
+     license_mask = 0
 
-This mask (representing 0xFFFFFFFF) overrides the package-specific license 
-checks, allowing all custom or extracted content to load in the game.

--- a/docs/ac6_dlc_loading_guide.txt
+++ b/docs/ac6_dlc_loading_guide.txt
@@ -1,0 +1,113 @@
+================================================================================
+AC6 DLC Loading Guide
+================================================================================
+
+Goal: install and configure Xbox 360 DLC content (such as extra aircraft, 
+paint schemes, and missions) for use in the AC6 Recompiled PC port.
+
+
+--------------------------------------------------------------------------------
+0. Prerequisites
+--------------------------------------------------------------------------------
+
+- Your legally obtained Ace Combat 6 DLC packages (STFS containers).
+- Xenia Canary emulator installed on your system (used to manage and extract 
+  the DLC content).
+- The recompiled AC6 game executable (ac6recomp.exe) configured and running.
+
+
+--------------------------------------------------------------------------------
+1. Installing the DLC via Xenia Canary
+--------------------------------------------------------------------------------
+
+Xenia Canary manages DLC packages under a Title ID-based directory structure 
+and handles content extraction/decryption.
+
+1. Launch Xenia Canary.
+2. Select File -> Install Content from the top menu.
+3. Open your DLC package file (the STFS container). Xenia will automatically 
+   decrypt and extract the content to its local directory structure.
+
+Alternatively, you can manually extract the content from the packages using 
+third-party tools like Velocity or wxPirs.
+
+
+--------------------------------------------------------------------------------
+2. Locating the Extracted DLC Files
+--------------------------------------------------------------------------------
+
+Xenia Canary installs content into its local directory. Depending on how 
+Xenia Canary was set up:
+
+- By default, it is located in your Windows Documents folder:
+  %USERPROFILE%\Documents\Xenia\
+  
+- Alternatively, if running in portable mode, it will generate directories 
+  directly in the same folder where the xenia_canary.exe is located.
+
+TIP: You can easily open this directory directly from Xenia Canary by 
+selecting File -> Show content directory... from the top menu.
+
+Inside the Xenia directory, locate the Ace Combat 6 folder using the game's 
+Title ID (4E4D07D1). Navigate to the content subfolder:
+
+    ...\4E4D07D1\00000002\
+
+This folder will contain one or more subdirectories named after the DLC 
+package hashes (40-character hexadecimal strings). Each subdirectory 
+represents a DLC package containing the raw game data files (like 
+"dlcolorname.dat").
+
+Additionally, Xenia generates package headers (.header files) which are 
+located under:
+
+    ...\4E4D07D1\Headers\00000002\
+
+
+
+--------------------------------------------------------------------------------
+3. Copying DLC to the Recompiled Game VFS
+--------------------------------------------------------------------------------
+
+The recompiled PC port resolves DLC packages from its local user data directory, 
+which by default is:
+
+    %USERPROFILE%\Documents\ac6recomp\
+
+You must copy the directory structure and files from your Xenia directory into 
+your ac6recomp folder. 
+
+1. Copy the DLC content directories from Xenia to the PC port's content folder:
+   
+   Source: 
+   %USERPROFILE%\Documents\Xenia\4E4D07D1\00000002\<PackageHashFolder>
+   
+   Destination:
+   %USERPROFILE%\Documents\ac6recomp\0000000000000000\4E4D07D1\00000002\<PackageHashFolder>
+
+2. Copy the DLC package header files:
+   
+   Source: 
+   %USERPROFILE%\Documents\Xenia\4E4D07D1\Headers\00000002\<PackageHash>.header
+   
+   Destination:
+   %USERPROFILE%\Documents\ac6recomp\0000000000000000\4E4D07D1\Headers\00000002\<PackageHash>.header
+
+*Note: The root directory for the PC port's content uses "0000000000000000" 
+(representing XUID 0) for marketplace content.*
+
+
+--------------------------------------------------------------------------------
+4. Enabling DLC Licenses
+--------------------------------------------------------------------------------
+
+To bypass license checks for the copied DLC files, you must configure the 
+global license mask cvar in the game's configuration file.
+
+1. Open "ac6recomp.toml" in your game root directory.
+2. Add or modify the "license_mask" setting to enable all licenses:
+
+    license_mask = 4294967295
+
+This mask (representing 0xFFFFFFFF) overrides the package-specific license 
+checks, allowing all custom or extracted content to load in the game.

--- a/setup_and_build.bat
+++ b/setup_and_build.bat
@@ -119,6 +119,12 @@ echo.
 echo =========================================
 echo ISO Detection and Extraction
 echo =========================================
+set EXTRACT_DIR=assets
+if exist "!EXTRACT_DIR!\default.xex" if exist "!EXTRACT_DIR!\DATA.TBL" if exist "!EXTRACT_DIR!\DATA00.PAC" if exist "!EXTRACT_DIR!\DATA01.PAC" (
+    echo [OK] Assets folder already exists and contains default.xex and PAC data archives. Skipping ISO check and extraction.
+    goto :extraction_done
+)
+
 set ISO_FILE=
 for %%f in (*.iso) do (
     set ISO_FILE=%%f
@@ -144,21 +150,19 @@ if not exist "!EXTRACT_XISO_EXE!" (
     )
 )
 
-set EXTRACT_DIR=assets
-if exist "!EXTRACT_DIR!\default.xex" (
-    echo [OK] '!EXTRACT_DIR!\default.xex' already exists. Skipping extraction.
-) else (
-    echo Extracting '!ISO_FILE!' to '!EXTRACT_DIR!' directory...
-    if not exist "!EXTRACT_DIR!" mkdir "!EXTRACT_DIR!"
-    !EXTRACT_XISO_EXE! -d "!EXTRACT_DIR!" "!ISO_FILE!"
-    if !errorlevel! neq 0 (
-        echo [ERROR] Failed to extract ISO.
-        pause
-        exit /b 1
-    )
-    echo [OK] Extraction complete!
+echo Extracting '!ISO_FILE!' to '!EXTRACT_DIR!' directory...
+if not exist "!EXTRACT_DIR!" mkdir "!EXTRACT_DIR!"
+!EXTRACT_XISO_EXE! -d "!EXTRACT_DIR!" "!ISO_FILE!"
+if !errorlevel! neq 0 (
+    echo [ERROR] Failed to extract ISO.
+    pause
+    exit /b 1
 )
+echo [OK] Extraction complete!
+
+:extraction_done
 echo.
+
 
 echo =========================================
 echo Building the Game (MSVC Backend)


### PR DESCRIPTION
This PR adds a generalized DLC loading guide under docs/ac6_dlc_loading_guide.txt and updates the README.md file to link all existing documentation walkthroughs.