### PR TITLE
Working Linux Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(AC6RECOMP_SOURCES
     src/ac6_pac_index.cpp
     src/d3d_hooks.cpp
     src/render_hooks.cpp
-    src/ac6_texture_overrides.cpp
+    src/ac6_texture_swap_cvars.cpp
     src/ac6_native_graphics.cpp
     src/ac6_native_graphics_overlay.cpp
     src/ac6_backend_fixes/ac6_backend_capture_bridge.cpp
@@ -49,6 +49,12 @@ set(AC6RECOMP_SOURCES
     src/ac6_backend_fixes/ac6_widescreen.cpp
 )
 
+# Texture swapping is reachable only from the D3D12 texture cache, which is not
+# built on non-Windows hosts, so the translation unit would have no callers there.
+if(WIN32)
+    list(APPEND AC6RECOMP_SOURCES src/ac6_texture_overrides.cpp)
+endif()
+
 if(WIN32)
     add_executable(ac6recomp WIN32 ${AC6RECOMP_SOURCES})
 else()
@@ -57,8 +63,29 @@ endif()
 
 rexglue_setup_target(ac6recomp)
 
+# The SDK's xmemory.cpp reads cvars owned by graphics/flags.cpp while rexgraphics
+# already links rexsystem, so the two static archives are mutually dependent.
+# Declaring the back-edge makes CMake repeat them on the link line. On Windows the
+# symbol resolves by accident, because d3d12/command_processor.cpp references the
+# same cvar and pulls flags.cpp.o in ahead of rexsystem; a Vulkan-only build has no
+# such earlier reference and the rexglue tool fails to link. Applied here rather
+# than in the SDK to keep the vendored tree pristine.
+if(TARGET rexsystem AND TARGET rexgraphics)
+    target_link_libraries(rexsystem PUBLIC rexgraphics)
+endif()
+
 # Link libmspack for AC6 PAC LZX decompression in the runtime dump path.
 target_link_libraries(ac6recomp PRIVATE mspack)
+
+# The input driver looks for the gamepad mappings next to the executable, but the
+# binary stays in the build tree rather than an install directory, so put a copy
+# there on every build.
+add_custom_command(TARGET ac6recomp POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_CURRENT_SOURCE_DIR}/gamecontrollerdb.txt"
+        "$<TARGET_FILE_DIR:ac6recomp>"
+    COMMENT "Copying gamecontrollerdb.txt next to ac6recomp"
+)
 
 if(AC6RECOMP_IPO_SUPPORTED)
     set_property(TARGET ac6recomp PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,10 +27,10 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-20",
-                "CMAKE_CXX_COMPILER": "clang++-20",
-                "CMAKE_C_FLAGS": "-march=x86-64-v3",
-                "CMAKE_CXX_FLAGS": "-march=x86-64-v3",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_C_FLAGS": "-march=x86-64-v3 -w",
+                "CMAKE_CXX_FLAGS": "-march=x86-64-v3 -w",
                 "REXSDK_DIR": "${sourceDir}/thirdparty/rexglue-sdk"
             },
             "condition": {

--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -1,0 +1,24 @@
+# SDL gamepad mappings shipped with ac6recomp.
+#
+# Only devices SDL does not already recognise belong here. SDL's Linux backend
+# auto-generates a mapping only for evdev nodes that advertise gamepad-class
+# buttons (BTN_GAMEPAD/BTN_SOUTH and friends). A stick that the kernel binds to
+# hid-generic instead of xpad reports joystick-class buttons (BTN_TRIGGER...),
+# fails that test, and is then invisible to the gamepad API entirely.
+#
+# Format reference: https://wiki.libsdl.org/SDL3/SDL_AddGamepadMapping
+# The path to this file is the `hid_mappings_file` cvar, under [Input].
+
+# Thrustmaster T.Flight Hotas One (USB 044f:b68d).
+# The PC/Xbox switch makes no difference on Linux -- same VID/PID, same version,
+# same hid-generic binding either way -- so this one line covers both positions.
+#
+# Layout notes, since several bindings are not the obvious ones:
+#   - Throttle (a2) is split into both triggers: forward drives RT, back drives LT.
+#   - Yaw twist (a5) is split into the shoulder buttons: left LB, right RB.
+#   - Trim L/R is an axis (a7), not a pair of buttons, so it drives dpup/dpdown.
+#   - Button 7 ("B/7") fires LT and RT together, hence the duplicate outputs.
+#   - The coolie hat is the right stick, which leaves dpleft/dpright unbound;
+#     that is deliberate, AC6 does not need them.
+#   - Raw inputs left unused: buttons 2, 8, 9, 12, 13, 14 and axes 3, 4, 6.
+030000004f0400008db6000011010000,Thrustmaster T.Flight Hotas One,platform:Linux,a:b0,b:b1,x:b4,y:b3,back:b5,start:b11,leftstick:b7,rightstick:b10,leftshoulder:-a5,rightshoulder:+a5,lefttrigger:+a2,righttrigger:-a2,lefttrigger:b6,righttrigger:b6,leftx:a0,lefty:a1,+rightx:h0.2,-rightx:h0.8,+righty:h0.4,-righty:h0.1,dpup:-a7,dpdown:+a7,

--- a/src/ac6_backend_fixes/ac6_fullres_effects.cpp
+++ b/src/ac6_backend_fixes/ac6_fullres_effects.cpp
@@ -20,11 +20,16 @@
 // registry, so the game stays self-consistent downstream. The emulator sees
 // an ordinary full-res surface - no RT-cache changes needed.
 
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h>
+#else
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
 
 #include <atomic>
 #include <cstdint>
@@ -288,6 +293,7 @@ std::atomic<uint32_t> g_downscaler_resolve_pending{0};
 std::atomic<uint32_t> g_mask_base{0};
 
 bool SafeCopyU32Array(const uint32_t* host, uint32_t* out, uint32_t count) noexcept {
+#if defined(_WIN32)
     __try {
         for (uint32_t i = 0; i < count; ++i) {
             out[i] = host[i];
@@ -296,6 +302,19 @@ bool SafeCopyU32Array(const uint32_t* host, uint32_t* out, uint32_t count) noexc
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         return false;
     }
+#else
+    // The source is guest memory, which is an shm mapping: a page can be
+    // readable and still unbacked, so a plain dereference raises SIGBUS rather
+    // than a recoverable fault. process_vm_readv performs the access in the
+    // kernel and reports EFAULT instead of signalling, which is the guard this
+    // needs. SEH_TRY was the other candidate, but it recovers by throwing from
+    // a signal handler - far heavier than a bounded read, and it would have to
+    // be armed on every thread that can reach here.
+    iovec local{out, size_t(count) * sizeof(uint32_t)};
+    iovec remote{const_cast<uint32_t*>(host), size_t(count) * sizeof(uint32_t)};
+    return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) ==
+           ssize_t(size_t(count) * sizeof(uint32_t));
+#endif
 }
 }  // namespace
 
@@ -355,8 +374,8 @@ void FxNoteResolveDest(uint32_t dest_obj, uint8_t* base) {
         return;
     }
     // words are big-endian; fetch dword_1 (base+fmt) at [8], dword_2 (dims) at [9].
-    const uint32_t d1 = _byteswap_ulong(words[8]);
-    const uint32_t d2 = _byteswap_ulong(words[9]);
+    const uint32_t d1 = rex::byte_swap(words[8]);
+    const uint32_t d2 = rex::byte_swap(words[9]);
     const uint32_t view_base = (d1 >> 12) << 12;
     const uint32_t phys_base = view_base & 0x1FFFFFFFu;  // strip the 0xA0/0xC0 view
     const uint32_t w = (d2 & 0x1FFF) + 1;

--- a/src/ac6_backend_fixes/ac6_widescreen.cpp
+++ b/src/ac6_backend_fixes/ac6_widescreen.cpp
@@ -28,18 +28,26 @@
 // the presenter is forced to letterbox: menus, hangar, briefing, FMV and the
 // attract demo render exactly vanilla.
 
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h>
+#else
+#include <sys/mman.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #include <native/ui/presenter.h>
@@ -59,14 +67,29 @@ REXCVAR_DEFINE_BOOL(ac6_widescreen_cinematics, true, "AC6/Enhancements",
 // Read (never written) only to report it in the activation log.
 REXCVAR_DECLARE(bool, present_letterbox);
 
+// This file drives guest camera objects directly, which needs three things the
+// host OS provides differently: enumerating readable guest memory, reading a
+// word that may fault, and writing one that may fault. Windows uses
+// VirtualQuery plus __try/__except; POSIX uses process_vm_readv (the access
+// happens in the kernel and reports EFAULT instead of raising SIGSEGV/SIGBUS -
+// necessary because guest memory is an shm mapping where a page can be
+// readable yet unbacked) and mprotect. Everything above that split is shared.
+
 namespace {
 
 constexpr float kNativeAspect = 1.7777778f;  // BE 0x3FE38E39, exactly what the game stores
+constexpr uint64_t kGuestScanBegin = 0x00010000ull;  // page 0 is the null guard
 constexpr uint64_t kGuestScanEnd = 0xC0000000ull;  // C0/E0 views alias A0 - skip them
+#if !defined(_WIN32)
+// Chunk the POSIX sweep reads guest memory in. Large enough that the syscall
+// cost is negligible against the copy, small enough to keep the scratch buffer
+// off the "large allocation" path.
+constexpr size_t kSweepChunkBytes = 1u << 20;
+#endif
 // Mode poll every 250 ms (a cheap 3-dereference guest read) so mission
 // transitions re-aim the cameras promptly; the full memory sweep still runs on
 // the 2 s cadence (8 polls) or immediately on a transition.
-constexpr DWORD kModePollMs = 250;
+constexpr uint32_t kModePollMs = 250;
 constexpr uint32_t kSweepEveryPolls = 8;
 
 // The game's front end is a mode-task state machine (docs/re/subsystems/
@@ -198,14 +221,25 @@ void MarkerGuardsResetForSwap() {
 uint32_t HostBitsOf(float value) {
   uint32_t bits;
   std::memcpy(&bits, &value, sizeof(bits));
-  return _byteswap_ulong(bits);  // little-endian dword whose bytes read big-endian
+  return rex::byte_swap(bits);  // little-endian dword whose bytes read big-endian
 }
 
-// SEH-safe single-word accessors for the poke paths. Note the SDK's vectored
-// handler runs BEFORE these __except filters, so a write fault on a
-// GPU-write-watched physical page is still recovered transparently (like any
-// guest write); only genuinely unrecoverable access violations land here and
-// are reported as failure instead of crashing the process.
+// Fault-tolerant single-word accessors for the poke paths.
+//
+// Windows: the SDK's vectored handler runs BEFORE these __except filters, so a
+// write fault on a GPU-write-watched physical page is still recovered
+// transparently (like any guest write); only genuinely unrecoverable access
+// violations land here and are reported as failure instead of crashing.
+//
+// POSIX: reads go through process_vm_readv so an unbacked shm page reports
+// EFAULT instead of raising SIGBUS. Writes deliberately do NOT use
+// process_vm_writev - a kernel-side write would bypass the SDK's userspace
+// write-watch SIGSEGV handler, so the GPU would never learn the page changed.
+// Instead the address is probed for readability first (which rejects the
+// unmapped case) and then written normally, leaving write-watch semantics
+// exactly as they are for any other guest write.
+#if defined(_WIN32)
+
 bool SafeReadU32(const uint32_t* p, uint32_t* out) noexcept {
   __try {
     *out = *p;
@@ -224,6 +258,56 @@ bool SafeWriteU32(uint32_t* p, uint32_t value) noexcept {
   }
 }
 
+#else  // !_WIN32
+
+bool SafeReadU32(const uint32_t* p, uint32_t* out) noexcept {
+  iovec local{out, sizeof(*out)};
+  iovec remote{const_cast<uint32_t*>(p), sizeof(*out)};
+  return process_vm_readv(getpid(), &local, 1, &remote, 1, 0) == ssize_t(sizeof(*out));
+}
+
+bool SafeWriteU32(uint32_t* p, uint32_t value) noexcept {
+  uint32_t probe;
+  if (!SafeReadU32(p, &probe)) {
+    return false;
+  }
+  *p = value;
+  return true;
+}
+
+#endif  // _WIN32
+
+// Makes a host range writable. The XEX image copy holding the static default
+// aspect is mapped read-only, so the poke needs this first. Already-writable
+// pages make it a no-op on both platforms, so callers need no separate query.
+// Only ever applied to the two fixed static addresses - never to swept heap
+// pages, whose read-only state may be the SDK's GPU write watching and must be
+// left for the SDK's own handler to recover.
+bool MakeHostWritable(void* p, size_t bytes) noexcept {
+#if defined(_WIN32)
+  DWORD old_protect;
+  return VirtualProtect(p, bytes, PAGE_READWRITE, &old_protect) != 0;
+#else
+  const uintptr_t page = uintptr_t(sysconf(_SC_PAGESIZE));
+  const uintptr_t start = uintptr_t(p) & ~(page - 1);
+  const size_t len = size_t(uintptr_t(p) + bytes - start);
+  return mprotect(reinterpret_cast<void*>(start), len, PROT_READ | PROT_WRITE) == 0;
+#endif
+}
+
+// Reads a block of guest memory into a caller-owned buffer, returning the
+// number of bytes actually obtained (0 if nothing there, short if the range
+// runs into a gap). Used by the sweep on POSIX, where the scan works on a copy
+// rather than in place.
+#if !defined(_WIN32)
+size_t SafeReadBlock(const void* p, void* out, size_t bytes) noexcept {
+  iovec local{out, bytes};
+  iovec remote{const_cast<void*>(p), bytes};
+  const ssize_t got = process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+  return got < 0 ? 0 : size_t(got);
+}
+#endif
+
 // Big-endian guest dword read through the translated view, SEH-safe.
 bool SafeReadGuestU32(rex::memory::Memory* memory, uint32_t guest_ea, uint32_t* out) {
   if (!guest_ea) {
@@ -233,7 +317,7 @@ bool SafeReadGuestU32(rex::memory::Memory* memory, uint32_t guest_ea, uint32_t* 
   if (!SafeReadU32(memory->TranslateVirtual<const uint32_t*>(guest_ea), &raw)) {
     return false;
   }
-  *out = _byteswap_ulong(raw);
+  *out = rex::byte_swap(raw);
   return true;
 }
 
@@ -253,29 +337,40 @@ uint32_t ReadCurrentScreenId(rex::memory::Memory* memory) {
   return vtable;
 }
 
+// Is words[i] an aspect field whose neighbours look like a camera (fov, near,
+// far in sane ranges)? Pure predicate over an already-safe buffer - shared by
+// both platforms' sweeps.
+bool CameraSignatureAt(const uint32_t* words, size_t i, size_t count, uint32_t aspect_pattern,
+                       uint32_t prev_pattern) {
+  if (i < 1 || i + 2 >= count) {
+    return false;
+  }
+  if (words[i] != aspect_pattern && (!prev_pattern || words[i] != prev_pattern)) {
+    return false;
+  }
+  uint32_t w;
+  float fov, near_plane, far_plane;
+  w = rex::byte_swap(words[i - 1]);
+  std::memcpy(&fov, &w, sizeof(fov));
+  w = rex::byte_swap(words[i + 1]);
+  std::memcpy(&near_plane, &w, sizeof(near_plane));
+  w = rex::byte_swap(words[i + 2]);
+  std::memcpy(&far_plane, &w, sizeof(far_plane));
+  return fov > 0.05f && fov < 2.0f && near_plane > 0.005f && near_plane < 10.0f &&
+         far_plane > 1000.0f && far_plane < 200000.0f;
+}
+
+#if defined(_WIN32)
 // The raw signature scan, SEH-guarded against pages vanishing mid-read.
-// Scalar-only frame so __try is legal. Finds dwords equal to the big-endian
-// 16:9 aspect whose neighbors look like a camera (fov, near, far in sane
-// ranges); returns match count, stores up to max_out dword indices.
+// Scalar-only frame so __try is legal; scans the live view in place. Returns
+// match count, stores up to max_out dword indices.
 size_t WideScanRegionRaw(const uint32_t* words, size_t count, uint32_t aspect_pattern,
                          uint32_t prev_pattern, uint32_t* out_indices,
                          size_t max_out) noexcept {
   size_t n = 0;
   __try {
     for (size_t i = 1; i + 2 < count; ++i) {
-      if (words[i] != aspect_pattern && (!prev_pattern || words[i] != prev_pattern)) {
-        continue;
-      }
-      uint32_t w;
-      float fov, near_plane, far_plane;
-      w = _byteswap_ulong(words[i - 1]);
-      std::memcpy(&fov, &w, sizeof(fov));
-      w = _byteswap_ulong(words[i + 1]);
-      std::memcpy(&near_plane, &w, sizeof(near_plane));
-      w = _byteswap_ulong(words[i + 2]);
-      std::memcpy(&far_plane, &w, sizeof(far_plane));
-      if (fov > 0.05f && fov < 2.0f && near_plane > 0.005f && near_plane < 10.0f &&
-          far_plane > 1000.0f && far_plane < 200000.0f) {
+      if (CameraSignatureAt(words, i, count, aspect_pattern, prev_pattern)) {
         if (n < max_out) {
           out_indices[n] = uint32_t(i);
         }
@@ -286,6 +381,7 @@ size_t WideScanRegionRaw(const uint32_t* words, size_t count, uint32_t aspect_pa
   }
   return n;
 }
+#endif  // _WIN32
 
 // The previously applied target's big-endian pattern (0 = none) - lets the
 // static defaults be retargeted when the auto-derived aspect changes (window
@@ -306,12 +402,9 @@ void PatchStaticDefaults(rex::memory::Memory* memory, uint32_t aspect_pattern,
     uint32_t* host = memory->TranslateVirtual<uint32_t*>(guest);
     // Early in boot the page may not be committed yet (this runs from ~2s
     // after graphics init, during the startup logo) - skip and retry on the
-    // next sweep rather than touching it.
-    MEMORY_BASIC_INFORMATION mbi{};
-    if (!VirtualQuery(host, &mbi, sizeof(mbi)) || mbi.State != MEM_COMMIT ||
-        (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD))) {
-      continue;
-    }
+    // next sweep rather than touching it. SafeReadU32 already reports an
+    // uncommitted page as failure on both platforms, so the read IS the
+    // commit check.
     uint32_t cur;
     if (!SafeReadU32(host, &cur)) {
       continue;
@@ -327,33 +420,75 @@ void PatchStaticDefaults(rex::memory::Memory* memory, uint32_t aspect_pattern,
         ++unexpected_logs;
         REXLOG_ERROR("[AC6-WIDE] static default @ 0x{:08X}: unexpected 0x{:08X} "
                      "(expected 16:9), skipping",
-                     guest, _byteswap_ulong(cur));
+                     guest, rex::byte_swap(cur));
       }
       continue;
     }
     // The XEX image copy may be mapped read-only - unprotect before writing
     // (kept writable; this field is re-checked every sweep anyway).
-    bool need_unprotect =
-        !(mbi.Protect & (PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READWRITE |
-                         PAGE_EXECUTE_WRITECOPY));
-    if (need_unprotect) {
-      DWORD old_protect;
-      if (!VirtualProtect(host, sizeof(uint32_t), PAGE_READWRITE, &old_protect)) {
-        if (unexpected_logs < 4) {
-          ++unexpected_logs;
-          REXLOG_ERROR("[AC6-WIDE] static default @ 0x{:08X}: read-only and unprotect "
-                       "failed, skipping",
-                       guest);
-        }
-        continue;
+    if (!MakeHostWritable(host, sizeof(uint32_t))) {
+      if (unexpected_logs < 4) {
+        ++unexpected_logs;
+        REXLOG_ERROR("[AC6-WIDE] static default @ 0x{:08X}: read-only and unprotect "
+                     "failed, skipping",
+                     guest);
       }
+      continue;
     }
     if (SafeWriteU32(host, target_bits) && patch_logs < 8) {
       ++patch_logs;
-      REXLOG_ERROR("[AC6-WIDE] static default @ 0x{:08X}: 1.77778 -> {:g}{}", guest, target,
-                   need_unprotect ? " (page unprotected)" : "");
+      REXLOG_ERROR("[AC6-WIDE] static default @ 0x{:08X}: 1.77778 -> {:g}", guest, target);
     }
   }
+}
+
+// Is the guest page holding this address writable, according to the SDK's own
+// page tracking? Used on POSIX in place of a host protection query - it is the
+// same source of truth the guest itself sees, and on Linux it reads the
+// in-process protection shadow rather than parsing /proc/self/maps.
+bool GuestRangeWritable(rex::memory::Memory* memory, uint32_t guest_ea) {
+  auto* heap = memory->LookupHeap(guest_ea);
+  if (!heap) {
+    return false;
+  }
+  const rex::memory::PageAccess access = heap->QueryRangeAccess(guest_ea, guest_ea + 3);
+  return access == rex::memory::PageAccess::kReadWrite ||
+         access == rex::memory::PageAccess::kExecuteReadWrite;
+}
+
+// Poke one camera's aspect field, given its guest address. Shared by both
+// platforms' sweeps: it works purely off guest EAs, so it does not care
+// whether the scan ran in place (Windows) or over a copy (POSIX).
+bool PokeCameraAspect(rex::memory::Memory* memory, uint32_t hit_guest, bool region_writable,
+                      uint32_t to_bits, float to_value) {
+  static uint32_t poke_logs = 0;
+  static uint32_t skipped_ro_logs = 0;
+  // Physical-view pages (>= 0xA0000000) may be read-only due to the SDK's GPU
+  // write watching; the poke faults and the SDK's handler recovers it like any
+  // guest write. A read-only page in a plain virtual heap has no such
+  // recovery - skip those.
+  if (!region_writable && hit_guest < 0xA0000000u) {
+    if (skipped_ro_logs < 4) {
+      ++skipped_ro_logs;
+      REXLOG_ERROR("[AC6-WIDE] camera @ 0x{:08X} in read-only region, skipping", hit_guest);
+    }
+    return false;
+  }
+  uint32_t* field = memory->TranslateVirtual<uint32_t*>(hit_guest);
+  uint32_t fov_word = 0;
+  SafeReadU32(field - 1, &fov_word);
+  const uint32_t w = rex::byte_swap(fov_word);
+  float fov;
+  std::memcpy(&fov, &w, sizeof(fov));
+  if (!SafeWriteU32(field, to_bits)) {
+    return false;
+  }
+  if (poke_logs < 32) {
+    ++poke_logs;
+    REXLOG_ERROR("[AC6-WIDE] camera aspect @ 0x{:08X} (fov={:g}) -> {:g}", hit_guest, fov,
+                 to_value);
+  }
+  return true;
 }
 
 // Signature-scan committed guest memory for camera objects whose aspect field
@@ -370,14 +505,16 @@ uint32_t WidescreenSweep(rex::memory::Memory* memory, uint32_t match_a, uint32_t
     REXLOG_ERROR("[AC6-WIDE] first sweep starting");
   }
 
-  static uint32_t poke_logs = 0;
   static uint32_t sweep_logs = 0;
-  static uint32_t skipped_ro_logs = 0;
-  constexpr size_t kMaxRegionMatches = 64;
-  uint32_t indices[kMaxRegionMatches];
   uint32_t patched = 0;
 
-  uint64_t guest = 0x00010000;
+#if defined(_WIN32)
+  // Windows: walk the committed regions with VirtualQuery and scan each one in
+  // place - no copy, the __try in WideScanRegionRaw covers a page vanishing
+  // mid-scan.
+  constexpr size_t kMaxRegionMatches = 64;
+  uint32_t indices[kMaxRegionMatches];
+  uint64_t guest = kGuestScanBegin;
   while (guest < kGuestScanEnd) {
     uint8_t* host = memory->TranslateVirtual(uint32_t(guest));
     MEMORY_BASIC_INFORMATION mbi{};
@@ -400,38 +537,50 @@ uint32_t WidescreenSweep(rex::memory::Memory* memory, uint32_t match_a, uint32_t
                                        match_a, match_b, indices, kMaxRegionMatches);
       size_t stored = std::min(found, kMaxRegionMatches);
       for (size_t h = 0; h < stored; ++h) {
-        uint32_t hit_guest = uint32_t(guest + uint64_t(indices[h]) * 4);
-        // Physical-view pages (>= 0xA0000000) may be read-only due to the
-        // SDK's GPU write watching; the poke faults and the SDK's handler
-        // recovers it like any guest write. A read-only page in a plain
-        // virtual heap has no such recovery - skip those.
-        if (!writable && hit_guest < 0xA0000000u) {
-          if (skipped_ro_logs < 4) {
-            ++skipped_ro_logs;
-            REXLOG_ERROR("[AC6-WIDE] camera @ 0x{:08X} in read-only region, skipping",
-                         hit_guest);
-          }
-          continue;
-        }
-        uint32_t* field = reinterpret_cast<uint32_t*>(host + uint64_t(indices[h]) * 4);
-        uint32_t fov_word = 0;
-        SafeReadU32(field - 1, &fov_word);
-        uint32_t w = _byteswap_ulong(fov_word);
-        float fov;
-        std::memcpy(&fov, &w, sizeof(fov));
-        if (!SafeWriteU32(field, to_bits)) {
-          continue;
-        }
-        ++patched;
-        if (poke_logs < 32) {
-          ++poke_logs;
-          REXLOG_ERROR("[AC6-WIDE] camera aspect @ 0x{:08X} (fov={:g}) -> {:g}", hit_guest,
-                       fov, to_value);
+        if (PokeCameraAspect(memory, uint32_t(guest + uint64_t(indices[h]) * 4), writable,
+                             to_bits, to_value)) {
+          ++patched;
         }
       }
     }
     guest += len;
   }
+#else
+  // POSIX: there is no VirtualQuery, and /proc/self/maps is far too slow to
+  // parse per sweep. Instead stride the guest range in chunks read through
+  // process_vm_readv, which fails cleanly on anything unmapped - so the walk
+  // needs no protection map at all - and scan the copy. Writability comes from
+  // the SDK's own page tracking rather than the host mapping.
+  std::vector<uint32_t> chunk(kSweepChunkBytes / 4);
+  uint64_t guest = kGuestScanBegin;
+  while (guest < kGuestScanEnd) {
+    const size_t want = size_t(std::min<uint64_t>(kSweepChunkBytes, kGuestScanEnd - guest));
+    const size_t got =
+        SafeReadBlock(memory->TranslateVirtual(uint32_t(guest)), chunk.data(), want);
+    if (!got) {
+      guest += want;  // nothing mapped here - stride past it
+      continue;
+    }
+    const size_t words = got / 4;
+    const bool writable = GuestRangeWritable(memory, uint32_t(guest));
+    for (size_t i = 1; i + 2 < words; ++i) {
+      if (!CameraSignatureAt(chunk.data(), i, words, match_a, match_b)) {
+        continue;
+      }
+      if (PokeCameraAspect(memory, uint32_t(guest + uint64_t(i) * 4), writable, to_bits,
+                           to_value)) {
+        ++patched;
+      }
+    }
+    guest += got;
+    // A short read means the chunk ran into an unmapped page; step over it so
+    // the next iteration starts past the gap instead of retrying the same one.
+    if (got < want) {
+      guest += 0x1000;
+    }
+  }
+#endif
+
   if (first_sweep) {
     first_sweep = false;
     REXLOG_ERROR("[AC6-WIDE] first sweep done");
@@ -444,7 +593,7 @@ uint32_t WidescreenSweep(rex::memory::Memory* memory, uint32_t match_a, uint32_t
   return patched;
 }
 
-DWORD WINAPI WidescreenThread(LPVOID) {
+void WidescreenThread() {
   const uint32_t native_bits = HostBitsOf(kNativeAspect);
   uint32_t poll_count = 0;
   bool last_in_mission = false;
@@ -458,7 +607,7 @@ DWORD WINAPI WidescreenThread(LPVOID) {
   // cheap and continues) so the front end is not scanned forever.
   uint32_t clean_reverts = 0;
   for (;;) {
-    Sleep(kModePollMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(kModePollMs));
     bool enabled = REXCVAR_GET(ac6_widescreen);
     rex::memory::Memory* memory = g_ws_memory.load(std::memory_order_acquire);
     // Mode poll, every cycle: cheap SEH-safe 3-dereference guest read. A null
@@ -573,7 +722,6 @@ DWORD WINAPI WidescreenThread(LPVOID) {
       }
     }
   }
-  return 0;
 }
 
 }  // namespace
@@ -602,7 +750,7 @@ void WidescreenInit(rex::memory::Memory* memory) {
                    REXCVAR_GET(ac6_widescreen_cinematics) ? 1 : 0,
                    REXCVAR_GET(present_letterbox) ? 1 : 0);
     }
-    CreateThread(nullptr, 0, WidescreenThread, nullptr, 0, nullptr);
+    std::thread(WidescreenThread).detach();
   });
 }
 
@@ -774,11 +922,11 @@ void WidescreenShrinkMarkerQuads(uint8_t* vertices, uint32_t vertex_stride, uint
       } else if (indices_32bit) {
         uint32_t raw;
         std::memcpy(&raw, indices + at * 4, sizeof(raw));
-        vi = _byteswap_ulong(raw);
+        vi = rex::byte_swap(raw);
       } else {
         uint16_t raw;
         std::memcpy(&raw, indices + at * 2, sizeof(raw));
-        vi = _byteswap_ushort(raw);
+        vi = rex::byte_swap(raw);
       }
       if (vi >= kMarkerMaxVertices) {
         b.valid = false;
@@ -789,8 +937,8 @@ void WidescreenShrinkMarkerQuads(uint8_t* vertices, uint32_t vertex_stride, uint
       uint32_t raw_x, raw_y;
       std::memcpy(&raw_x, vp, sizeof(raw_x));
       std::memcpy(&raw_y, vp + sizeof(float), sizeof(raw_y));
-      raw_x = _byteswap_ulong(raw_x);
-      raw_y = _byteswap_ulong(raw_y);
+      raw_x = rex::byte_swap(raw_x);
+      raw_y = rex::byte_swap(raw_y);
       std::memcpy(&x[c], &raw_x, sizeof(x[c]));
       std::memcpy(&y[c], &raw_y, sizeof(y[c]));
       if (!std::isfinite(x[c]) || !std::isfinite(y[c])) {
@@ -874,12 +1022,12 @@ void WidescreenShrinkMarkerQuads(uint8_t* vertices, uint32_t vertex_stride, uint
         uint8_t* vp = vertices + size_t(b.vi[c]) * vertex_stride + pos_offset;
         uint32_t raw;
         std::memcpy(&raw, vp, sizeof(raw));
-        raw = _byteswap_ulong(raw);
+        raw = rex::byte_swap(raw);
         float vx;
         std::memcpy(&vx, &raw, sizeof(vx));
         float nx = cx + (vx - cx) * shrink;
         std::memcpy(&raw, &nx, sizeof(raw));
-        raw = _byteswap_ulong(raw);
+        raw = rex::byte_swap(raw);
         std::memcpy(vp, &raw, sizeof(raw));
       }
     }

--- a/src/ac6_texture_overrides.cpp
+++ b/src/ac6_texture_overrides.cpp
@@ -19,20 +19,14 @@
 
 REXCVAR_DECLARE(std::string, user_data_root);
 
-REXCVAR_DEFINE_BOOL(ac6_texture_swaps_enabled, false, "AC6/TextureSwaps",
-                    "Enable AC6 texture dump and replacement support (default off: the "
-                    "replacement lookup currently checks the filesystem on every texture "
-                    "upload, which can cause frame stutters; enable for texture modding)");
-REXCVAR_DEFINE_BOOL(ac6_texture_swaps_dump_enabled, false, "AC6/TextureSwaps",
-                    "Dump host-ready textures to the user-data texture dump folder");
-REXCVAR_DEFINE_BOOL(ac6_texture_swaps_replace_enabled, false, "AC6/TextureSwaps",
-                    "Load matching replacement DDS files from the user-data texture override folders");
-REXCVAR_DEFINE_STRING(ac6_texture_swaps_dump_dir, "texture_dumps", "AC6/TextureSwaps",
-                      "User-data subdirectory that stores dumped texture DDS files and metadata");
-REXCVAR_DEFINE_STRING(ac6_texture_swaps_override_dir, "override/textures", "AC6/TextureSwaps",
-                      "User-data subdirectory that stores loose replacement texture DDS files");
-REXCVAR_DEFINE_STRING(ac6_texture_swaps_mods_dir, "mods", "AC6/TextureSwaps",
-                      "User-data subdirectory containing mod folders with texture overrides");
+// Defined in ac6_texture_swap_cvars.cpp, which is built on every platform - this
+// translation unit is Windows-only (it needs the D3D12/DXGI format enums).
+REXCVAR_DECLARE(bool, ac6_texture_swaps_enabled);
+REXCVAR_DECLARE(bool, ac6_texture_swaps_dump_enabled);
+REXCVAR_DECLARE(bool, ac6_texture_swaps_replace_enabled);
+REXCVAR_DECLARE(std::string, ac6_texture_swaps_dump_dir);
+REXCVAR_DECLARE(std::string, ac6_texture_swaps_override_dir);
+REXCVAR_DECLARE(std::string, ac6_texture_swaps_mods_dir);
 
 namespace ac6::textures {
 namespace {

--- a/src/ac6_texture_swap_cvars.cpp
+++ b/src/ac6_texture_swap_cvars.cpp
@@ -1,0 +1,30 @@
+// Texture-swap cvar definitions.
+//
+// These live apart from ac6_texture_overrides.cpp because that translation unit
+// needs <d3d12.h>/<dxgiformat.h> for the DXGI_FORMAT and D3D12_RESOURCE_DIMENSION
+// enums its DDS layout math is written against, so it is only built on Windows.
+// The cvars themselves are part of the user-facing config surface (they appear in
+// ac6recomp.toml and the F4 overlay) and are read from main.cpp and the status
+// overlay, so they must be defined on every platform.
+//
+// Once texture swapping is wired into the Vulkan texture cache these can move
+// back, along with a portable DXGI_FORMAT enum shim.
+
+#include <string>
+
+#include <rex/cvar.h>
+
+REXCVAR_DEFINE_BOOL(ac6_texture_swaps_enabled, false, "AC6/TextureSwaps",
+                    "Enable AC6 texture dump and replacement support (default off: the "
+                    "replacement lookup currently checks the filesystem on every texture "
+                    "upload, which can cause frame stutters; enable for texture modding)");
+REXCVAR_DEFINE_BOOL(ac6_texture_swaps_dump_enabled, false, "AC6/TextureSwaps",
+                    "Dump host-ready textures to the user-data texture dump folder");
+REXCVAR_DEFINE_BOOL(ac6_texture_swaps_replace_enabled, false, "AC6/TextureSwaps",
+                    "Load matching replacement DDS files from the user-data texture override folders");
+REXCVAR_DEFINE_STRING(ac6_texture_swaps_dump_dir, "texture_dumps", "AC6/TextureSwaps",
+                      "User-data subdirectory that stores dumped texture DDS files and metadata");
+REXCVAR_DEFINE_STRING(ac6_texture_swaps_override_dir, "override/textures", "AC6/TextureSwaps",
+                      "User-data subdirectory that stores loose replacement texture DDS files");
+REXCVAR_DEFINE_STRING(ac6_texture_swaps_mods_dir, "mods", "AC6/TextureSwaps",
+                      "User-data subdirectory containing mod folders with texture overrides");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 // This file is yours to edit. 'rexglue migrate' will NOT overwrite it.
 
 #include <rex/cvar.h>
+#include <rex/graphics/pipeline/texture/cache.h>
 #include <rex/logging.h>
 
 REXCVAR_DECLARE(bool, ac6_render_capture);
@@ -165,11 +166,19 @@ void EnforceAc6PerformanceModeOverrides() {
 }
 
 void ApplyAc6FixDefaults() {
-    // Post-config, these read the USER's draw scale - with the old app-create
+    // Post-config, this reads the USER's draw scale - with the old app-create
     // timing this gate always saw the default 1x, so the scaling fix payload
     // never engaged for anyone who set their scale in the toml.
-    const bool scaled = REXCVAR_GET(draw_resolution_scale_x) > 1 ||
-                        REXCVAR_GET(draw_resolution_scale_y) > 1;
+    //
+    // Ask the texture cache for the EFFECTIVE scale rather than reading
+    // draw_resolution_scale_x/y: the combined resolution_scale cvar - what the
+    // settings menu writes - leaves those two at 1, so reading them alone left
+    // the fixes off for everyone who scaled that way.
+    uint32_t effective_scale_x = 1;
+    uint32_t effective_scale_y = 1;
+    rex::graphics::TextureCache::GetConfigDrawResolutionScale(effective_scale_x,
+                                                              effective_scale_y);
+    const bool scaled = effective_scale_x > 1 || effective_scale_y > 1;
 
     // param_gen floor + host sub-pixel restore only bites at >1x --
     // inert at 1x, so gate it on the draw scale.
@@ -240,8 +249,14 @@ void ApplyAc6PerformanceModeOverridesPublic() {
 // This is the support line: it shows whether a master switch genuinely
 // disengaged its payload.
 void LogAc6ConfigPresetSummary() {
-    REXLOG_ERROR("AC6 config: graphics mode={} capture={}", REXCVAR_GET(ac6_graphics_mode),
-                 REXCVAR_GET(ac6_render_capture) ? "true" : "false");
+    uint32_t effective_scale_x = 1;
+    uint32_t effective_scale_y = 1;
+    rex::graphics::TextureCache::GetConfigDrawResolutionScale(effective_scale_x,
+                                                              effective_scale_y);
+    REXLOG_ERROR("AC6 config: graphics mode={} capture={} draw scale={}x{}",
+                 REXCVAR_GET(ac6_graphics_mode),
+                 REXCVAR_GET(ac6_render_capture) ? "true" : "false", effective_scale_x,
+                 effective_scale_y);
     REXLOG_ERROR("AC6 fixes: scaling={} deswizzle={} dof={} water_line={} perf_mode={} "
                  "unlock_fps={}",
                  REXCVAR_GET(ac6_fix_scaling), REXCVAR_GET(ac6_fix_deswizzle),

--- a/thirdparty/rexglue-sdk/include/native/audio/audio_driver.h
+++ b/thirdparty/rexglue-sdk/include/native/audio/audio_driver.h
@@ -11,6 +11,19 @@
 
 namespace rex::audio {
 
+// Guest render-driver frames needed to cover one host device period. A device
+// period that is not a whole number of 256-sample guest frames still has to be
+// satisfied from whole frames, so this rounds up; without the round-up the host
+// asks for more audio than the runtime is ever allowed to queue and the
+// shortfall is filled with silence on every callback.
+constexpr uint32_t RequiredQueueFramesForDevice(const uint32_t device_buffer_frames,
+                                                const uint32_t headroom_frames = 0) {
+  const uint32_t buffer_frames = device_buffer_frames > 0 ? device_buffer_frames : 1u;
+  const uint32_t periods =
+      (buffer_frames + kRenderDriverTicSamplesPerFrame - 1) / kRenderDriverTicSamplesPerFrame;
+  return (periods > 3u ? periods : 3u) + headroom_frames;
+}
+
 class AudioDriver {
  public:
   explicit AudioDriver(memory::Memory* memory);

--- a/thirdparty/rexglue-sdk/include/native/audio/sdl/sdl_audio_driver.h
+++ b/thirdparty/rexglue-sdk/include/native/audio/sdl/sdl_audio_driver.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <queue>
 #include <stack>
+#include <vector>
 
 #include <SDL3/SDL_audio.h>
 
@@ -31,10 +32,15 @@ class SdlAudioDriver : public AudioDriver {
   void SubmitSilenceFrame() override;
   AudioDriverTelemetry GetTelemetry() const override;
   const char* backend_name() const override { return "sdl"; }
-  uint32_t queue_low_water_frames() const override { return 2; }
-  uint32_t queue_target_frames() const override { return 3; }
+  uint32_t queue_low_water_frames() const override;
+  uint32_t queue_target_frames() const override;
 
  private:
+  // Slack above the device period, absorbing worker wake jitter. The POSIX
+  // multi-handle wait is a 1ms poll rather than a real blocking wait, so the
+  // refill can lag a consumed frame by more than a scheduler tick.
+  static constexpr uint32_t kQueueHeadroomFrames = 2;
+
   static void SDLCALL StreamCallback(void* userdata, SDL_AudioStream* stream,
                                      int additional_amount, int total_amount);
   void FillStream(SDL_AudioStream* stream, int bytes_needed);
@@ -43,9 +49,20 @@ class SdlAudioDriver : public AudioDriver {
   size_t client_index_{0};
   SDL_AudioStream* stream_{nullptr};
 
+  float* AcquireFrameBufferLocked();
+
+  // SDL's device period, queried from the device rather than assumed. Defaults
+  // to SDL's own fallback for 48kHz so a failed query still sizes the queue
+  // sanely. Atomic because queue_target_frames() is called from the audio
+  // worker while Initialize() runs on another thread.
+  std::atomic<uint32_t> device_buffer_frames_{1024};
+
   std::mutex frames_mutex_{};
   std::queue<float*> frames_queued_{};
   std::stack<float*> frames_unused_{};
+  // Backing store for the whole pool, so the realtime callback never contends
+  // with a thread sitting inside the allocator.
+  std::vector<float> frame_pool_storage_{};
   std::array<float, kRenderDriverTicSamplesPerFrame * 2> pending_output_frame_{};
   size_t pending_output_float_count_{0};
   size_t pending_output_float_offset_{0};
@@ -57,6 +74,7 @@ class SdlAudioDriver : public AudioDriver {
   std::atomic<uint32_t> silence_injections_{0};
   std::atomic<uint32_t> queued_depth_{0};
   std::atomic<uint32_t> peak_queued_depth_{0};
+  std::atomic<uint32_t> dropped_frames_{0};
 };
 
 }  // namespace rex::audio::sdl

--- a/thirdparty/rexglue-sdk/include/native/exception_handler.h
+++ b/thirdparty/rexglue-sdk/include/native/exception_handler.h
@@ -295,6 +295,15 @@ class ExceptionHandler {
 
   static void Install(Handler fn, void* data);
   static void Uninstall(Handler fn, void* data);
+
+  // Called when no installed Handler claims a fault, just before the process is
+  // allowed to die on it. Lets a higher layer that knows about guest state
+  // (which this one deliberately does not) print a report first. POSIX only -
+  // on Windows an unclaimed access violation already unwinds the SEH chain into
+  // the crash handler.
+  typedef void (*UnhandledReporter)(uint64_t fault_address, uint64_t host_pc, bool is_write);
+
+  static void SetUnhandledReporter(UnhandledReporter fn);
 };
 
 }  // namespace rex::arch

--- a/thirdparty/rexglue-sdk/include/rex/graphics/vulkan/command_processor.h
+++ b/thirdparty/rexglue-sdk/include/rex/graphics/vulkan/command_processor.h
@@ -449,6 +449,9 @@ class VulkanCommandProcessor : public CommandProcessor {
   void InvalidateAllVertexBufferResidency();
   void InvalidateVertexBufferResidency(uint32_t vfetch_index);
   void InvalidateVertexBufferResidencyRange(uint32_t first_vfetch, uint32_t last_vfetch);
+  static std::pair<uint32_t, uint32_t> VertexBufferMemoryInvalidationCallbackThunk(
+      void* context_ptr, uint32_t physical_address_start, uint32_t length, bool exact_range);
+  bool AC6TerrainHdEnsureRing();
   struct ReadbackBuffer {
     VkBuffer buffers[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
     VkDeviceMemory memories[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
@@ -762,6 +765,13 @@ class VulkanCommandProcessor : public CommandProcessor {
   // Bit is set when the vertex buffer at that index has been requested in the
   // current frame. Cleared between frames and on fetch constant writes.
   uint64_t vertex_buffers_in_sync_[2] = {};
+  // AC6 (ac6_fix_trails): set by the guest thread when it writes watched
+  // GPU-visible memory, consumed on the GPU thread at the next draw.
+  std::atomic<bool> vertex_buffer_memory_invalidated_{false};
+  void* vertex_buffer_memory_invalidation_callback_handle_ = nullptr;
+  // AC6 HD terrain (ac6_terrain_hd): synthetic vertex-fetch-95 ring table.
+  bool ac6_hd_active_ = false;
+  uint32_t ac6_hd_ring_phys_ = 0;  // UINT32_MAX = allocation failed
   std::unordered_map<uint64_t, ReadbackBuffer> readback_buffers_;
   std::unordered_map<uint64_t, ReadbackBuffer> memexport_readback_buffers_;
 

--- a/thirdparty/rexglue-sdk/include/rex/graphics/vulkan/deferred_command_buffer.h
+++ b/thirdparty/rexglue-sdk/include/rex/graphics/vulkan/deferred_command_buffer.h
@@ -210,6 +210,26 @@ class DeferredCommandBuffer {
                 regions, sizeof(VkBufferImageCopy) * region_count);
   }
 
+  VkBufferImageCopy* CmdCopyImageToBufferEmplace(VkImage src_image, VkImageLayout src_image_layout,
+                                                 VkBuffer dst_buffer, uint32_t region_count) {
+    const size_t header_size =
+        rex::align(sizeof(ArgsVkCopyImageToBuffer), alignof(VkBufferImageCopy));
+    uint8_t* args_ptr = reinterpret_cast<uint8_t*>(WriteCommand(
+        Command::kVkCopyImageToBuffer, header_size + sizeof(VkBufferImageCopy) * region_count));
+    auto& args = *reinterpret_cast<ArgsVkCopyImageToBuffer*>(args_ptr);
+    args.src_image = src_image;
+    args.src_image_layout = src_image_layout;
+    args.dst_buffer = dst_buffer;
+    args.region_count = region_count;
+    return reinterpret_cast<VkBufferImageCopy*>(args_ptr + header_size);
+  }
+  void CmdVkCopyImageToBuffer(VkImage src_image, VkImageLayout src_image_layout,
+                              VkBuffer dst_buffer, uint32_t region_count,
+                              const VkBufferImageCopy* regions) {
+    std::memcpy(CmdCopyImageToBufferEmplace(src_image, src_image_layout, dst_buffer, region_count),
+                regions, sizeof(VkBufferImageCopy) * region_count);
+  }
+
   void CmdVkCopyQueryPoolResults(VkQueryPool query_pool, uint32_t first_query, uint32_t query_count,
                                  VkBuffer dst_buffer, VkDeviceSize dst_offset, VkDeviceSize stride,
                                  VkQueryResultFlags flags) {
@@ -363,6 +383,7 @@ class DeferredCommandBuffer {
     kVkClearColorImage,
     kVkCopyBuffer,
     kVkCopyBufferToImage,
+    kVkCopyImageToBuffer,
     kVkCopyQueryPoolResults,
     kVkDispatch,
     kVkDraw,
@@ -473,6 +494,15 @@ class DeferredCommandBuffer {
     uint32_t region_count;
     // Followed by aligned VkBufferCopy[].
     static_assert(alignof(VkBufferCopy) <= alignof(uintmax_t));
+  };
+
+  struct ArgsVkCopyImageToBuffer {
+    VkImage src_image;
+    VkImageLayout src_image_layout;
+    VkBuffer dst_buffer;
+    uint32_t region_count;
+    // Followed by aligned VkBufferImageCopy[].
+    static_assert(alignof(VkBufferImageCopy) <= alignof(uintmax_t));
   };
 
   struct ArgsVkCopyBufferToImage {

--- a/thirdparty/rexglue-sdk/include/rex/input/sdl/sdl_input_driver.h
+++ b/thirdparty/rexglue-sdk/include/rex/input/sdl/sdl_input_driver.h
@@ -77,6 +77,7 @@ class SDLInputDriver final : public InputDriver, public rex::ui::WindowListener 
   void ProcessEventLocked(const SDL_Event& event);
   void OnControllerDeviceAddedLocked(const SDL_Event& event);
   void OnControllerDeviceRemovedLocked(const SDL_Event& event);
+  void OnJoystickDeviceAddedLocked(const SDL_Event& event);
   void OnControllerDeviceAxisMotionLocked(const SDL_Event& event);
   void OnControllerDeviceButtonChangedLocked(const SDL_Event& event);
 

--- a/thirdparty/rexglue-sdk/include/rex/platform/dynlib.h
+++ b/thirdparty/rexglue-sdk/include/rex/platform/dynlib.h
@@ -22,6 +22,10 @@ class DynamicLibrary {
   DynamicLibrary& operator=(DynamicLibrary&& other) noexcept;
 
   bool Load(const std::filesystem::path& path);
+  // Obtains a handle ONLY if the library is already present in the process,
+  // never loading it. For probing whether a tool has injected itself: a plain
+  // dlopen would load the library and make the probe true by asking.
+  bool LoadIfAlreadyLoaded(const std::filesystem::path& path);
   void Close();
   explicit operator bool() const { return handle_ != nullptr; }
 

--- a/thirdparty/rexglue-sdk/src/core/dynlib_posix.cpp
+++ b/thirdparty/rexglue-sdk/src/core/dynlib_posix.cpp
@@ -30,6 +30,14 @@ bool DynamicLibrary::Load(const std::filesystem::path& path) {
   return handle_ != nullptr;
 }
 
+bool DynamicLibrary::LoadIfAlreadyLoaded(const std::filesystem::path& path) {
+  Close();
+  // RTLD_NOLOAD returns a handle only when the library is already mapped; it
+  // still takes a reference, so Close()'s dlclose stays balanced.
+  handle_ = dlopen(path.c_str(), RTLD_LAZY | RTLD_NOLOAD);
+  return handle_ != nullptr;
+}
+
 void DynamicLibrary::Close() {
   if (handle_) {
     dlclose(handle_);

--- a/thirdparty/rexglue-sdk/src/core/dynlib_win.cpp
+++ b/thirdparty/rexglue-sdk/src/core/dynlib_win.cpp
@@ -30,6 +30,13 @@ bool DynamicLibrary::Load(const std::filesystem::path& path) {
   return handle_ != nullptr;
 }
 
+bool DynamicLibrary::LoadIfAlreadyLoaded(const std::filesystem::path& path) {
+  // Unchanged Windows behaviour: these DLLs are not on the default search path
+  // unless the tool injected itself, so LoadLibraryW already only succeeds when
+  // it is genuinely present, and Close()'s FreeLibrary stays balanced.
+  return Load(path);
+}
+
 void DynamicLibrary::Close() {
   if (handle_) {
     FreeLibrary(static_cast<HMODULE>(handle_));

--- a/thirdparty/rexglue-sdk/src/core/exception_handler_posix.cpp
+++ b/thirdparty/rexglue-sdk/src/core/exception_handler_posix.cpp
@@ -30,6 +30,7 @@ namespace rex::arch {
 bool signal_handlers_installed_ = false;
 struct sigaction original_sigill_handler_;
 struct sigaction original_sigsegv_handler_;
+ExceptionHandler::UnhandledReporter unhandled_reporter_ = nullptr;
 
 // This can be as large as needed, but isn't often needed.
 // As we will be sometimes firing many exceptions we want to avoid having to
@@ -205,6 +206,51 @@ static void ExceptionHandlerCallback(int signal_number, siginfo_t* signal_info,
       return;
     }
   }
+
+  // Nothing claimed the fault.
+  //
+  // Returning here re-executes the faulting instruction, which faults again -
+  // the thread spins inside the signal handler forever, burning a core, with no
+  // diagnostic anywhere. That is a POSIX-only failure mode: on Windows an
+  // unclaimed access violation runs off the end of the SEH chain and terminates
+  // the process, so the same guest fault is loud and immediate there and shows
+  // up here as an unexplained "deadlock" instead.
+  //
+  // Report it, then restore the default disposition and return. The faulting
+  // instruction re-executes once more and dies in SIG_DFL, which terminates the
+  // process with a core dump pointing at the real faulting instruction rather
+  // than at a re-raise inside this handler.
+  const uint64_t fault_address = uint64_t(signal_info->si_addr);
+  const uint64_t kGuestVirtualBase = 0x100000000ull;
+  const uint64_t kGuestVirtualSize = 0x100000000ull;
+  if (signal_number == SIGSEGV && fault_address >= kGuestVirtualBase &&
+      fault_address < kGuestVirtualBase + kGuestVirtualSize) {
+    REXLOG_ERROR(
+        "[FAULT] unhandled access violation at guest address {:#010x} (host {:#x}), host rip={:#x}. "
+        "Nothing has this mapped - most likely a guest null pointer. Terminating, as Windows "
+        "would, instead of retrying the instruction forever.",
+        fault_address - kGuestVirtualBase, fault_address, thread_context.rip);
+  } else {
+    REXLOG_ERROR("[FAULT] unhandled signal {} at address {:#x}, host rip={:#x}. Terminating.",
+                 signal_number, fault_address, thread_context.rip);
+  }
+
+  // Let the guest-aware layer describe what the title was doing, before the
+  // default disposition takes the process down.
+  if (unhandled_reporter_) {
+    unhandled_reporter_(fault_address, thread_context.rip,
+                        ex.access_violation_operation() ==
+                            Exception::AccessViolationOperation::kWrite);
+  }
+
+  struct sigaction default_action;
+  std::memset(&default_action, 0, sizeof(default_action));
+  default_action.sa_handler = SIG_DFL;
+  sigaction(signal_number, &default_action, nullptr);
+}
+
+void ExceptionHandler::SetUnhandledReporter(UnhandledReporter fn) {
+  unhandled_reporter_ = fn;
 }
 
 void ExceptionHandler::Install(Handler fn, void* data) {

--- a/thirdparty/rexglue-sdk/src/core/filesystem_posix.cpp
+++ b/thirdparty/rexglue-sdk/src/core/filesystem_posix.cpp
@@ -151,14 +151,27 @@ class PosixFileHandle : public FileHandle {
   bool Read(size_t file_offset, void* buffer, size_t buffer_length,
             size_t* out_bytes_read) override {
     ssize_t out = pread(handle_, buffer, buffer_length, file_offset);
-    *out_bytes_read = out;
-    return out >= 0 ? true : false;
+    // On failure pread returns -1, which as a size_t is SIZE_MAX - reporting a
+    // colossal transfer to a caller that may not check the bool.
+    *out_bytes_read = out < 0 ? 0 : size_t(out);
+    if (out < 0) {
+      return false;
+    }
+    // A read starting at or past the end must FAIL, so HostPathFile turns it
+    // into X_STATUS_END_OF_FILE the way the guest kernel does. Win32 ReadFile
+    // does that for us (ERROR_HANDLE_EOF); pread just returns 0, which reaches
+    // the guest as "success, zero bytes, position unchanged" - a loader reading
+    // a file to its end then never terminates.
+    return out != 0 || buffer_length == 0;
   }
   bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
              size_t* out_bytes_written) override {
     ssize_t out = pwrite(handle_, buffer, buffer_length, file_offset);
-    *out_bytes_written = out;
-    return out >= 0 ? true : false;
+    *out_bytes_written = out < 0 ? 0 : size_t(out);
+    // A short write is a failure (a full disk reports one), and the atomic
+    // write path must see it as such rather than committing a truncated temp
+    // over a good file.
+    return out >= 0 && size_t(out) == buffer_length;
   }
   bool SetLength(size_t length) override { return ftruncate(handle_, length) >= 0 ? true : false; }
   void Flush() override { fsync(handle_); }
@@ -169,24 +182,26 @@ class PosixFileHandle : public FileHandle {
 
 std::unique_ptr<FileHandle> FileHandle::OpenExisting(const std::filesystem::path& path,
                                                      uint32_t desired_access) {
-  int open_access = 0;
-  if (desired_access & FileAccess::kGenericRead) {
-    open_access |= O_RDONLY;
-  }
-  if (desired_access & FileAccess::kGenericWrite) {
-    open_access |= O_WRONLY;
-  }
-  if (desired_access & FileAccess::kGenericExecute) {
-    open_access |= O_RDONLY;
-  }
-  if (desired_access & FileAccess::kGenericAll) {
-    open_access |= O_RDWR;
-  }
-  if (desired_access & FileAccess::kFileReadData) {
-    open_access |= O_RDONLY;
-  }
-  if (desired_access & FileAccess::kFileWriteData) {
-    open_access |= O_WRONLY;
+  // O_RDONLY/O_WRONLY/O_RDWR are an enumeration in the low two bits (0/1/2),
+  // not bit flags, so they cannot be OR-ed together: read|write ORs to 1, which
+  // is O_WRONLY, and every read on that descriptor then fails with EBADF. The
+  // title opens its save read+write, so the reads silently returned nothing and
+  // it wrote back whatever its buffer already held. Windows has no equivalent
+  // problem - GENERIC_READ|GENERIC_WRITE really are bit flags.
+  const bool wants_read =
+      (desired_access & (FileAccess::kGenericRead | FileAccess::kGenericExecute |
+                         FileAccess::kFileReadData | FileAccess::kGenericAll)) != 0;
+  const bool wants_write =
+      (desired_access & (FileAccess::kGenericWrite | FileAccess::kFileWriteData |
+                         FileAccess::kFileAppendData | FileAccess::kGenericAll)) != 0;
+
+  int open_access;
+  if (wants_read && wants_write) {
+    open_access = O_RDWR;
+  } else if (wants_write) {
+    open_access = O_WRONLY;
+  } else {
+    open_access = O_RDONLY;
   }
   if (desired_access & FileAccess::kFileAppendData) {
     open_access |= O_APPEND;

--- a/thirdparty/rexglue-sdk/src/core/memory_posix.cpp
+++ b/thirdparty/rexglue-sdk/src/core/memory_posix.cpp
@@ -14,6 +14,9 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <map>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 
 #include <fcntl.h>
@@ -109,6 +112,143 @@ uint32_t ToPosixProtectFlags(PageAccess access) {
 bool IsWritableExecutableMemorySupported() {
   return true;
 }
+
+// Protection shadow.
+//
+// Windows answers QueryProtect with VirtualQuery, a cheap syscall. There is no
+// POSIX equivalent, so this file originally answered it by parsing
+// /proc/self/maps. That is ruinous here: the MMIO handler calls QueryProtect on
+// *every* access violation to check whether another thread already cleared the
+// watch, and guest write-watches fault constantly. Each call opened a file and
+// sscanf'd ~1000 lines while holding the global critical region, which measured
+// at 39% of total process CPU with the guest making no progress at all.
+//
+// mprotect goes through Protect() and mmap through AllocFixed(), so this
+// process is the only writer of its own protections and can simply remember
+// them. Ranges are page-aligned and coalesced; a lookup that misses falls back
+// to the maps file, which keeps addresses this module never handed out (host
+// allocations, the stack) answering exactly as before.
+namespace {
+
+struct ProtRange {
+  uintptr_t end = 0;
+  PageAccess access = PageAccess::kNoAccess;
+};
+
+std::shared_mutex g_prot_shadow_mutex;
+// Keyed by range start; ranges are non-overlapping and kept sorted.
+std::map<uintptr_t, ProtRange> g_prot_shadow;
+
+uintptr_t PageAlignDown(uintptr_t address) {
+  return address & ~static_cast<uintptr_t>(page_size() - 1);
+}
+
+uintptr_t PageAlignUp(uintptr_t address) {
+  const uintptr_t mask = static_cast<uintptr_t>(page_size() - 1);
+  return (address + mask) & ~mask;
+}
+
+// Callers must hold the lock exclusively. Coalescing is suppressed by the
+// unmap path, which needs [begin, end) to stay a range of its own so it can
+// then be erased without taking a neighbour with it.
+void ShadowInsertLocked(uintptr_t begin, uintptr_t end, PageAccess access,
+                        bool coalesce = true) {
+  if (begin >= end) {
+    return;
+  }
+
+  // Trim or split whatever already covers [begin, end).
+  auto it = g_prot_shadow.upper_bound(begin);
+  if (it != g_prot_shadow.begin()) {
+    --it;
+  }
+  while (it != g_prot_shadow.end() && it->first < end) {
+    const uintptr_t cur_begin = it->first;
+    const uintptr_t cur_end = it->second.end;
+    if (cur_end <= begin) {
+      ++it;
+      continue;
+    }
+    const PageAccess cur_access = it->second.access;
+    it = g_prot_shadow.erase(it);
+    if (cur_begin < begin) {
+      g_prot_shadow[cur_begin] = ProtRange{begin, cur_access};
+    }
+    if (cur_end > end) {
+      it = g_prot_shadow.insert(it, {end, ProtRange{cur_end, cur_access}});
+      ++it;
+    }
+  }
+
+  g_prot_shadow[begin] = ProtRange{end, access};
+
+  if (!coalesce) {
+    return;
+  }
+
+  // Coalesce with the neighbours so repeated re-arming of a watch cannot grow
+  // the map without bound.
+  auto inserted = g_prot_shadow.find(begin);
+  auto next = std::next(inserted);
+  if (next != g_prot_shadow.end() && next->first == inserted->second.end &&
+      next->second.access == access) {
+    inserted->second.end = next->second.end;
+    g_prot_shadow.erase(next);
+  }
+  if (inserted != g_prot_shadow.begin()) {
+    auto prev = std::prev(inserted);
+    if (prev->second.end == inserted->first && prev->second.access == access) {
+      prev->second.end = inserted->second.end;
+      g_prot_shadow.erase(inserted);
+    }
+  }
+}
+
+void ShadowRecord(void* base_address, size_t length, PageAccess access) {
+  if (!base_address || !length) {
+    return;
+  }
+  const uintptr_t begin = PageAlignDown(reinterpret_cast<uintptr_t>(base_address));
+  const uintptr_t end = PageAlignUp(reinterpret_cast<uintptr_t>(base_address) + length);
+  std::unique_lock<std::shared_mutex> lock(g_prot_shadow_mutex);
+  ShadowInsertLocked(begin, end, access);
+}
+
+void ShadowForget(void* base_address, size_t length) {
+  if (!base_address || !length) {
+    return;
+  }
+  const uintptr_t begin = PageAlignDown(reinterpret_cast<uintptr_t>(base_address));
+  const uintptr_t end = PageAlignUp(reinterpret_cast<uintptr_t>(base_address) + length);
+  std::unique_lock<std::shared_mutex> lock(g_prot_shadow_mutex);
+  // Insert uncoalesced first so any range straddling the boundaries is split,
+  // then drop everything inside. Coalescing here could merge the hole into a
+  // neighbour and leave the unmapped span still described.
+  ShadowInsertLocked(begin, end, PageAccess::kNoAccess, /*coalesce=*/false);
+  auto it = g_prot_shadow.lower_bound(begin);
+  while (it != g_prot_shadow.end() && it->first < end) {
+    it = g_prot_shadow.erase(it);
+  }
+}
+
+// Returns false if the address is not tracked, leaving the caller to fall back.
+bool ShadowLookup(void* address, PageAccess& access_out, uintptr_t& range_end_out) {
+  const uintptr_t addr = reinterpret_cast<uintptr_t>(address);
+  std::shared_lock<std::shared_mutex> lock(g_prot_shadow_mutex);
+  auto it = g_prot_shadow.upper_bound(addr);
+  if (it == g_prot_shadow.begin()) {
+    return false;
+  }
+  --it;
+  if (addr < it->first || addr >= it->second.end) {
+    return false;
+  }
+  access_out = it->second.access;
+  range_end_out = it->second.end;
+  return true;
+}
+
+}  // namespace
 
 // TODO(tomc): this needs to go somewhere else. we should utilize the platform namespace more.
 #if REX_PLATFORM_LINUX
@@ -236,6 +376,8 @@ void* AllocFixed(void* base_address, size_t length, AllocationType allocation_ty
 
   void* result = mmap(base_address, length, prot_initial, flags, -1, 0);
   if (result != MAP_FAILED) {
+    ShadowRecord(result, length,
+                 allocation_type == AllocationType::kReserve ? PageAccess::kNoAccess : access);
     return result;
   }
 #if defined(MAP_FIXED_NOREPLACE) && REX_PLATFORM_LINUX
@@ -247,6 +389,7 @@ void* AllocFixed(void* base_address, size_t length, AllocationType allocation_ty
     // Verify the entire range is mapped before using mprotect
     if (IsRangeFullyMapped(base_address, length)) {
       if (mprotect(base_address, length, static_cast<int>(prot_requested)) == 0) {
+        ShadowRecord(base_address, length, access);
         return base_address;
       }
     }
@@ -266,10 +409,15 @@ bool DeallocFixed(void* base_address, size_t length, DeallocationType deallocati
 #if defined(MADV_DONTNEED)
       (void)madvise(base_address, length, MADV_DONTNEED);
 #endif
+      ShadowRecord(base_address, length, PageAccess::kNoAccess);
       return true;
     }
     case DeallocationType::kRelease: {
-      return munmap(base_address, length) == 0;
+      if (munmap(base_address, length) != 0) {
+        return false;
+      }
+      ShadowForget(base_address, length);
+      return true;
     }
     default:
       // how we get here? :(
@@ -290,15 +438,25 @@ bool Protect(void* base_address, size_t length, PageAccess access, PageAccess* o
   //             atomic in a mutli-threaded process either, but it's something to be aware of.
   // Query old access before changing, if the caller needs it
   if (out_old_access) {
-    LinuxMapEntry e;
-    if (FindEntryForAddress(base_address, e)) {
-      *out_old_access = PermsToPageAccess(e.perms);
+    PageAccess shadow_access;
+    uintptr_t shadow_end;
+    if (ShadowLookup(base_address, shadow_access, shadow_end)) {
+      *out_old_access = shadow_access;
+    } else {
+      LinuxMapEntry e;
+      if (FindEntryForAddress(base_address, e)) {
+        *out_old_access = PermsToPageAccess(e.perms);
+      }
     }
   }
 #endif
 
   uint32_t prot = ToPosixProtectFlags(access);
-  return mprotect(base_address, length, prot) == 0;
+  if (mprotect(base_address, length, prot) != 0) {
+    return false;
+  }
+  ShadowRecord(base_address, length, access);
+  return true;
 }
 
 bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
@@ -309,6 +467,18 @@ bool QueryProtect(void* base_address, size_t& length, PageAccess& access_out) {
 #else
   access_out = PageAccess::kNoAccess;
   length = 0;
+
+  // The hot path: this runs on every access violation, so it must not touch the
+  // filesystem. Only addresses this module never protected reach the fallback.
+  {
+    PageAccess shadow_access;
+    uintptr_t shadow_end;
+    if (ShadowLookup(base_address, shadow_access, shadow_end)) {
+      access_out = shadow_access;
+      length = static_cast<size_t>(shadow_end - reinterpret_cast<uintptr_t>(base_address));
+      return true;
+    }
+  }
 
   LinuxMapEntry e;
   if (!FindEntryForAddress(base_address, e)) {

--- a/thirdparty/rexglue-sdk/src/core/threading_posix.cpp
+++ b/thirdparty/rexglue-sdk/src/core/threading_posix.cpp
@@ -13,14 +13,19 @@ static_assert(REX_PLATFORM_LINUX || REX_PLATFORM_MAC, "This file is POSIX-only")
 
 #include <signal.h>
 
+#include <algorithm>
 #include <atomic>
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstddef>
+#include <cstdio>
 #include <ctime>
 #include <deque>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <thread>
 
 #include <pthread.h>
 #include <semaphore.h>
@@ -32,6 +37,7 @@ static_assert(REX_PLATFORM_LINUX || REX_PLATFORM_MAC, "This file is POSIX-only")
 
 #include <rex/assert.h>
 #include <rex/chrono/chrono_steady_cast.h>
+#include <rex/cvar.h>
 #include <rex/logging.h>
 #include <rex/thread/timer_queue.h>
 
@@ -56,6 +62,20 @@ static_assert(REX_PLATFORM_LINUX || REX_PLATFORM_MAC, "This file is POSIX-only")
 #else
 #define REX_HAS_SIGEV_THREAD_ID 0
 #endif
+
+// The Win32 dispatcher hands an auto-reset release to one specific waiter, in
+// FIFO order; publishing a flag every waiter races for collapses two releases
+// into one and guarantees nobody in particular. Off restores that older
+// flag-based behaviour, so a suspected regression can be A/B'd without a
+// rebuild.
+REXCVAR_DEFINE_BOOL(posix_event_fifo_handoff, true, "Threading",
+                    "Hand auto-reset event releases to a specific waiter in FIFO order");
+
+// Milliseconds a single guest wait may run before the watchdog logs it as a
+// suspected deadlock, with the waiting thread, the object and the wait kind.
+// 0 disables the watchdog entirely.
+REXCVAR_DEFINE_UINT32(log_long_waits_ms, 0, "Threading",
+                      "Log guest waits that exceed this many milliseconds (0 = off)");
 
 namespace rex::thread {
 
@@ -234,8 +254,6 @@ class PosixConditionBase {
   virtual bool Signal() = 0;
 
   WaitResult Wait(std::chrono::milliseconds timeout) {
-    bool executed;
-    auto predicate = [this] { return this->signaled(); };
 #if REX_PLATFORM_LINUX
     auto native_mutex = static_cast<pthread_mutex_t*>(mutex_.native_handle());
     int lock_result = pthread_mutex_lock(native_mutex);
@@ -248,22 +266,46 @@ class PosixConditionBase {
 #else
     std::unique_lock<std::mutex> lock(mutex_);
 #endif
-    if (predicate()) {
-      executed = true;
-    } else {
-      if (timeout == std::chrono::milliseconds::max()) {
-        cond_.wait(lock, predicate);
-        executed = true;  // Did not time out;
-      } else {
-        executed = cond_.wait_for(lock, timeout, predicate);
-      }
-    }
-    if (executed) {
+    // Already satisfiable, so consume it directly without joining the queue.
+    if (signaled()) {
       post_execution();
       return WaitResult::kSuccess;
-    } else {
-      return WaitResult::kTimeout;
     }
+
+    // Otherwise take a place in line. A signaller hands the release to the
+    // waiter at the front rather than raising a flag every waiter races for -
+    // see GrantOneLocked.
+    const bool fifo_handoff = REXCVAR_GET(posix_event_fifo_handoff);
+    WaitToken token;
+    if (fifo_handoff) {
+      wait_queue_.push_back(&token);
+    }
+    auto predicate = [this, &token] { return token.granted || this->signaled(); };
+
+    bool predicate_met;
+    if (timeout == std::chrono::milliseconds::max()) {
+      cond_.wait(lock, predicate);
+      predicate_met = true;
+    } else {
+      predicate_met = cond_.wait_for(lock, timeout, predicate);
+    }
+
+    // Leave the queue before deciding anything: once we are out, no signaller
+    // can hand us a release we would then drop on the floor.
+    if (fifo_handoff) {
+      RemoveFromQueueLocked(&token);
+    }
+
+    if (token.granted) {
+      // The signaller already accounted for this release on our behalf, so the
+      // object state must not be consumed a second time here.
+      return WaitResult::kSuccess;
+    }
+    if (predicate_met && signaled()) {
+      post_execution();
+      return WaitResult::kSuccess;
+    }
+    return WaitResult::kTimeout;
   }
 
   static std::pair<WaitResult, size_t> WaitMultiple(std::vector<PosixConditionBase*>&& handles,
@@ -374,6 +416,54 @@ class PosixConditionBase {
  protected:
   inline virtual bool signaled() const = 0;
   inline virtual void post_execution() = 0;
+
+  // One entry per thread parked in Wait(), in arrival order.
+  //
+  // The Win32 dispatcher hands a release to a specific waiter, and does so in
+  // FIFO order. Publishing a flag and letting every waiter race for it is not
+  // equivalent in two ways that both strand guests: two releases delivered
+  // before any waiter runs collapse into one, and no waiter is guaranteed to
+  // ever win. Signallers therefore grant a token instead - see GrantOneLocked.
+  struct WaitToken {
+    bool granted = false;
+  };
+
+  // Hand the release to the longest-waiting thread. Returns false when nobody
+  // is queued, in which case the caller must fall back to recording the
+  // release in the object's own state so a later waiter can pick it up.
+  // Callers must hold mutex_.
+  bool GrantOneLocked() {
+    while (!wait_queue_.empty()) {
+      WaitToken* token = wait_queue_.front();
+      wait_queue_.pop_front();
+      if (!token->granted) {
+        token->granted = true;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Release everybody currently queued (manual-reset / broadcast semantics).
+  // Callers must hold mutex_.
+  void GrantAllLocked() {
+    for (WaitToken* token : wait_queue_) {
+      token->granted = true;
+    }
+    wait_queue_.clear();
+  }
+
+  // Callers must hold mutex_. Safe if the token was already dequeued by a grant.
+  void RemoveFromQueueLocked(WaitToken* token) {
+    for (auto it = wait_queue_.begin(); it != wait_queue_.end(); ++it) {
+      if (*it == token) {
+        wait_queue_.erase(it);
+        return;
+      }
+    }
+  }
+
+  std::deque<WaitToken*> wait_queue_;
   std::condition_variable cond_;
   std::mutex mutex_;
 };
@@ -394,7 +484,21 @@ class PosixCondition<Event> : public PosixConditionBase {
 
   bool Signal() override {
     auto lock = std::unique_lock<std::mutex>(mutex_);
-    signal_ = true;
+    if (!REXCVAR_GET(posix_event_fifo_handoff)) {
+      signal_ = true;
+    } else if (manual_reset_) {
+      // Stays signalled until Reset(), so everyone queued and everyone arriving
+      // later goes through.
+      signal_ = true;
+      GrantAllLocked();
+    } else if (!GrantOneLocked()) {
+      // Auto-reset with nobody waiting: retain the signal for the next waiter.
+      // When somebody *is* waiting we hand it to them and deliberately leave
+      // signal_ false - that is the "release one waiter and reset" the Win32
+      // dispatcher performs, and it is what keeps two Sets that arrive before
+      // either waiter runs from collapsing into a single release.
+      signal_ = true;
+    }
     cond_.notify_all();
     return true;
   }
@@ -1046,11 +1150,155 @@ PosixConditionHandle<Event>::PosixConditionHandle(bool manual_reset, bool initia
 template <>
 PosixConditionHandle<Thread>::PosixConditionHandle(pthread_t thread) : handle_(thread) {}
 
+namespace {
+
+// Deadlock diagnostics.
+//
+// A hung guest looks identical from the outside whatever the cause, so record
+// what every thread is blocked on while it is blocked. A watchdog then names
+// the stuck thread, the object and how long it has been there - which a stack
+// trace alone cannot give, since the backtrace shows the condition variable but
+// not which guest object it belongs to.
+//
+// The table is plain data with a fixed address so it can equally be read out of
+// a core or a live process under gdb:
+//     p rex::thread::(anonymous namespace)::g_wait_slots
+struct WaitSlot {
+  std::atomic<uint32_t> tid{0};
+  std::atomic<const void*> object{nullptr};
+  std::atomic<uint64_t> start_ms{0};
+  std::atomic<uint32_t> kind{0};  // 0 idle, 1 Wait, 2 SignalAndWait, 3 WaitMultiple
+  std::atomic<uint32_t> object_count{0};
+  std::atomic<bool> alertable{false};
+  std::atomic<bool> reported{false};
+  char name[32] = {};
+};
+
+constexpr size_t kMaxWaitSlots = 256;
+WaitSlot g_wait_slots[kMaxWaitSlots];
+std::atomic<size_t> g_wait_slot_count{0};
+
+const char* WaitKindName(uint32_t kind) {
+  switch (kind) {
+    case 1:
+      return "Wait";
+    case 2:
+      return "SignalAndWait";
+    case 3:
+      return "WaitMultiple";
+    default:
+      return "idle";
+  }
+}
+
+uint64_t MonotonicMs() {
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   std::chrono::steady_clock::now().time_since_epoch())
+                                   .count());
+}
+
+WaitSlot* AcquireWaitSlot() {
+  thread_local WaitSlot* slot = nullptr;
+  if (slot) {
+    return slot;
+  }
+  size_t index = g_wait_slot_count.fetch_add(1, std::memory_order_relaxed);
+  if (index >= kMaxWaitSlots) {
+    return nullptr;
+  }
+  slot = &g_wait_slots[index];
+  slot->tid.store(current_thread_system_id(), std::memory_order_relaxed);
+  if (pthread_getname_np(pthread_self(), slot->name, sizeof(slot->name)) != 0) {
+    slot->name[0] = '\0';
+  }
+  return slot;
+}
+
+// The watchdog only ever reads the table, so it cannot itself be blocked by
+// whatever the guest is stuck on.
+void StartWaitWatchdogOnce(uint32_t threshold_ms) {
+  static std::once_flag once;
+  std::call_once(once, [threshold_ms] {
+    std::thread([threshold_ms] {
+      pthread_setname_np(pthread_self(), "WaitWatchdog");
+      while (true) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        uint64_t now = MonotonicMs();
+        size_t count = std::min(g_wait_slot_count.load(std::memory_order_relaxed), kMaxWaitSlots);
+        for (size_t i = 0; i < count; ++i) {
+          auto& slot = g_wait_slots[i];
+          uint32_t kind = slot.kind.load(std::memory_order_acquire);
+          if (!kind) {
+            continue;
+          }
+          uint64_t start = slot.start_ms.load(std::memory_order_relaxed);
+          if (!start || now - start < threshold_ms) {
+            continue;
+          }
+          if (slot.reported.exchange(true, std::memory_order_relaxed)) {
+            continue;
+          }
+          REXLOG_ERROR(
+              "[WAITWD] tid={} '{}' stuck in {} for {} ms on object={:#x} count={} alertable={}",
+              slot.tid.load(std::memory_order_relaxed), slot.name, WaitKindName(kind), now - start,
+              reinterpret_cast<uintptr_t>(slot.object.load(std::memory_order_relaxed)),
+              slot.object_count.load(std::memory_order_relaxed),
+              slot.alertable.load(std::memory_order_relaxed));
+        }
+      }
+    }).detach();
+  });
+}
+
+// Marks the calling thread as blocked for as long as it is in scope.
+class ScopedWaitRecord {
+ public:
+  ScopedWaitRecord(uint32_t kind, const void* object, uint32_t object_count, bool alertable) {
+    uint32_t threshold_ms = REXCVAR_GET(log_long_waits_ms);
+    if (!threshold_ms) {
+      return;
+    }
+    StartWaitWatchdogOnce(threshold_ms);
+    slot_ = AcquireWaitSlot();
+    if (!slot_) {
+      return;
+    }
+    slot_->object.store(object, std::memory_order_relaxed);
+    slot_->object_count.store(object_count, std::memory_order_relaxed);
+    slot_->alertable.store(alertable, std::memory_order_relaxed);
+    slot_->start_ms.store(MonotonicMs(), std::memory_order_relaxed);
+    slot_->reported.store(false, std::memory_order_relaxed);
+    // Published last: a non-zero kind is what makes the entry live.
+    slot_->kind.store(kind, std::memory_order_release);
+  }
+
+  ~ScopedWaitRecord() {
+    if (!slot_) {
+      return;
+    }
+    if (slot_->reported.load(std::memory_order_relaxed)) {
+      REXLOG_ERROR("[WAITWD] tid={} '{}' released after {} ms",
+                     slot_->tid.load(std::memory_order_relaxed), slot_->name,
+                     MonotonicMs() - slot_->start_ms.load(std::memory_order_relaxed));
+    }
+    slot_->kind.store(0, std::memory_order_release);
+  }
+
+  ScopedWaitRecord(const ScopedWaitRecord&) = delete;
+  ScopedWaitRecord& operator=(const ScopedWaitRecord&) = delete;
+
+ private:
+  WaitSlot* slot_ = nullptr;
+};
+
+}  // namespace
+
 WaitResult Wait(WaitHandle* wait_handle, bool is_alertable, std::chrono::milliseconds timeout) {
   auto posix_wait_handle = dynamic_cast<PosixWaitHandle*>(wait_handle);
   if (posix_wait_handle == nullptr) {
     return WaitResult::kFailed;
   }
+  ScopedWaitRecord wait_record(1, wait_handle, 1, is_alertable);
   if (!is_alertable) {
     return posix_wait_handle->condition().Wait(timeout);
   }
@@ -1084,6 +1332,7 @@ WaitResult SignalAndWait(WaitHandle* wait_handle_to_signal, WaitHandle* wait_han
     return WaitResult::kFailed;
   }
 
+  ScopedWaitRecord wait_record(2, wait_handle_to_wait_on, 1, is_alertable);
   if (!is_alertable) {
     return posix_wait_handle_to_wait_on->condition().Wait(timeout);
   }
@@ -1116,6 +1365,8 @@ std::pair<WaitResult, size_t> WaitMultiple(WaitHandle* wait_handles[], size_t wa
     }
     conditions.push_back(&handle->condition());
   }
+  ScopedWaitRecord wait_record(3, wait_handles[0], uint32_t(wait_handle_count), is_alertable);
+
   if (!is_alertable) {
     return PosixConditionBase::WaitMultiple(std::move(conditions), wait_all, timeout);
   }

--- a/thirdparty/rexglue-sdk/src/graphics/pipeline/render_target/cache.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/pipeline/render_target/cache.cpp
@@ -1332,6 +1332,20 @@ void RenderTargetCache::ChangeOwnership(RenderTargetKey dest, uint32_t start_til
         // Only perform the copying when actually changing the latest owner, not
         // just the latest host depth owner - the transfer source is expected to
         // be different than the destination.
+        if (!transfer_source.IsEmpty() && transfer_source == dest) {
+          // The guard below is supposed to make this impossible. If it ever
+          // fires, a render target would be sampled while bound as its own
+          // attachment, which is undefined.
+          static bool logged = false;
+          if (!logged) {
+            logged = true;
+            REXGPU_ERROR(
+                "Render target would transfer to itself: key={:08X} base={} pitch32={} msaa={} "
+                "depth={}",
+                dest.key, uint32_t(dest.base_tiles), uint32_t(dest.pitch_tiles_at_32bpp),
+                uint32_t(dest.msaa_samples), uint32_t(dest.is_depth));
+          }
+        }
         if (!transfer_source.IsEmpty() && transfer_source != dest) {
           uint32_t transfer_end_tiles = std::min(it->second.end_tiles, extent_end);
           if (!resolve_clear_cutout ||

--- a/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator.cpp
@@ -21,6 +21,8 @@
 #include <fmt/format.h>
 
 #include <rex/assert.h>
+#include <rex/cvar.h>
+#include <rex/graphics/flags.h>
 #include <rex/graphics/pipeline/shader/spirv.h>
 #include <rex/graphics/pipeline/shader/spirv_translator.h>
 #include <rex/math.h>
@@ -2564,6 +2566,41 @@ void SpirvShaderTranslator::CompleteVertexOrTessEvalShaderInMain() {
         position_w);
   }
 
+  // AC6 sun-flare "square" fix - drop the flare's second billboard.
+  // This VS (ADF9AFC4C10921B9) emits two billboards per flare draw: V0-V3 =
+  // the visible glow quad, V4-V7 = a huge malformed quad (corners far
+  // off-screen, garbage UVs) that is invisible on real hardware but
+  // mis-renders in the emulator as a faint bright-edged rectangle. Cull it the
+  // same way as kill-vertex above: NaN the position of vertices with index >=
+  // the threshold so the rasterizer discards the primitive; V0-V3 (the real
+  // glow) are untouched. Port of the same fix in the DXBC translator - without
+  // it the cvar reports enabled and does nothing on Vulkan.
+  if (REXCVAR_GET(ac6_flare_drop_quad2) &&
+      current_shader().ucode_data_hash() == UINT64_C(0xADF9AFC4C10921B9) &&
+      shader_modification.vertex.host_vertex_shader_type ==
+          Shader::HostVertexShaderType::kVertex &&
+      input_vertex_index_ != spv::NoResult) {
+    int32_t ac6_drop_index_min = REXCVAR_GET(ac6_flare_drop_index_min);
+    if (ac6_drop_index_min < 0) {
+      ac6_drop_index_min = 0;
+    }
+    // Here gl_VertexIndex is a signed int (the DXBC path compares the unsigned
+    // SV_VertexID); the threshold is clamped non-negative just above, so the
+    // signed comparison selects the same vertices.
+    spv::Id ac6_drop_vertex =
+        builder_->createBinOp(spv::OpSGreaterThanEqual, type_bool_,
+                              builder_->createLoad(input_vertex_index_, spv::NoPrecision),
+                              builder_->makeIntConstant(ac6_drop_index_min));
+    spv::Id ac6_drop_nan = builder_->createUnaryOp(
+        spv::OpBitcast, type_float_, builder_->makeUintConstant(UINT32_C(0x7FC00000)));
+    position_xyz = builder_->createTriOp(
+        spv::OpSelect, type_float3_,
+        builder_->smearScalar(spv::NoPrecision, ac6_drop_vertex, type_bool3_),
+        builder_->smearScalar(spv::NoPrecision, ac6_drop_nan, type_float3_), position_xyz);
+    position_w =
+        builder_->createTriOp(spv::OpSelect, type_float_, ac6_drop_vertex, ac6_drop_nan, position_w);
+  }
+
   // Write the point size.
   if (output_point_size_ != spv::NoResult) {
     spv::Id point_size;
@@ -3136,6 +3173,20 @@ void SpirvShaderTranslator::StartFragmentShaderInMain() {
   // Pixel parameters.
   if (param_gen_interpolator != UINT32_MAX) {
     Modification modification = GetSpirvShaderModification();
+    // Snap the reverted position to the integer guest-pixel index. Reverting the
+    // resolution scale leaves a sub-guest-pixel fraction (.5 at 2x) that is only
+    // correct for shaders feeding PsParamGen straight to a tfetch. Shaders that
+    // instead do integer pixel-address maths on it - AC6's deferred EDRAM
+    // restore and de-swizzle passes - break, because their frac()-based bit
+    // extraction sees a multiplied period at >1x and scrambles the sample
+    // coordinate into a mosaic. Flooring makes that maths operate on integer
+    // guest pixels again, at the cost of those passes sampling at guest
+    // resolution; param_gen_host_subpixel_restore re-adds the sub-pixel later,
+    // at the texture fetch, so they regain full host resolution. Port of the
+    // same gate in dxbc_translator.cpp - without it both cvars are inert here.
+    const bool param_gen_floor_guest_position =
+        REXCVAR_GET(param_gen_integer_guest_position) ||
+        REXCVAR_GET(param_gen_host_subpixel_restore);
     // Rounding the position down, and taking the absolute value, so in case the
     // host GPU for some reason has quads used for derivative calculation at odd
     // locations, the left and top edges will have correct derivative magnitude
@@ -3166,6 +3217,10 @@ void SpirvShaderTranslator::StartFragmentShaderInMain() {
       param_gen_x = builder_->createNoContractionBinOp(
           spv::OpFMul, type_float_, param_gen_x,
           builder_->makeFloatConstant(1.0f / float(draw_resolution_scale_x_)));
+      if (param_gen_floor_guest_position) {
+        param_gen_x = builder_->createUnaryBuiltinCall(type_float_, ext_inst_glsl_std_450_,
+                                                       GLSLstd450Floor, param_gen_x);
+      }
     }
     param_gen_x = builder_->createUnaryBuiltinCall(type_float_, ext_inst_glsl_std_450_,
                                                    GLSLstd450FAbs, param_gen_x);
@@ -3202,6 +3257,10 @@ void SpirvShaderTranslator::StartFragmentShaderInMain() {
       param_gen_y = builder_->createNoContractionBinOp(
           spv::OpFMul, type_float_, param_gen_y,
           builder_->makeFloatConstant(1.0f / float(draw_resolution_scale_y_)));
+      if (param_gen_floor_guest_position) {
+        param_gen_y = builder_->createUnaryBuiltinCall(type_float_, ext_inst_glsl_std_450_,
+                                                       GLSLstd450Floor, param_gen_y);
+      }
     }
     param_gen_y = builder_->createUnaryBuiltinCall(type_float_, ext_inst_glsl_std_450_,
                                                    GLSLstd450FAbs, param_gen_y);

--- a/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator_alu.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator_alu.cpp
@@ -514,6 +514,11 @@ spv::Id SpirvShaderTranslator::ProcessVectorAluOperation(
       if (used_result_components & 0b0010) {
         operand_neg[0] =
             builder_->createNoContractionUnaryOp(spv::OpFNegate, type_float_, operand[0]);
+      }
+      // Negated Z feeds both the sc of the X-major case (component 1) and the
+      // tc of the Y-major case (component 0), so it must be created if either
+      // is needed - not only for component 1.
+      if (used_result_components & 0b0011) {
         operand_neg[2] =
             builder_->createNoContractionUnaryOp(spv::OpFNegate, type_float_, operand[2]);
       }
@@ -573,6 +578,11 @@ spv::Id SpirvShaderTranslator::ProcessVectorAluOperation(
               // tc = y < 0.0 ? -z : z
               ma_y_result[0] = builder_->createTriOp(spv::OpSelect, type_float_, y_is_neg,
                                                      operand_neg[2], operand[2]);
+            }
+            // The face id is its own component - the other two major-axis cases
+            // compute it under its own guard, and nesting it under tc left it
+            // unset whenever the id was wanted without the coordinate.
+            if (used_result_components & 0b1000) {
               // id = y < 0.0 ? 3.0 : 2.0
               ma_y_result[3] = builder_->createTriOp(spv::OpSelect, type_float_, y_is_neg,
                                                      builder_->makeFloatConstant(3.0f),

--- a/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator_fetch.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/pipeline/shader/spirv_translator_fetch.cpp
@@ -20,12 +20,68 @@
 
 #include <rex/assert.h>
 #include <rex/cvar.h>
+#include <rex/graphics/flags.h>
 #include <rex/graphics/pipeline/shader/spirv_translator.h>
+#include <rex/logging.h>
 #include <rex/math.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
 
 REXCVAR_DECLARE(bool, vfetch_index_rounding_bias);
 
 namespace rex::graphics {
+
+namespace {
+
+// "<hash>[:<slot>[+<slot>...]]" entries separated by comma/semicolon/whitespace.
+// A bare hash matches every tfetch slot in that shader; with a slot list, only
+// the listed Xenos tfetch slots match.
+//
+// NOTE: this mirrors UcodeHashSlotInList in dxbc_translator_fetch.cpp - the two
+// must stay in sync. Kept local rather than shared so the Windows/DXBC path is
+// untouched by the Vulkan port.
+bool Ac6UcodeHashSlotInList(uint64_t hash, uint32_t tfetch_index, const std::string& list) {
+  auto is_sep = [](char c) {
+    return c == ',' || c == ';' || c == ' ' || c == '\t' || c == '\n' || c == '\r';
+  };
+  size_t i = 0, n = list.size();
+  while (i < n) {
+    while (i < n && is_sep(list[i])) {
+      ++i;
+    }
+    size_t start = i;
+    while (i < n && !is_sep(list[i])) {
+      ++i;
+    }
+    if (i > start) {
+      std::string token = list.substr(start, i - start);
+      size_t colon = token.find(':');
+      std::string hash_part = colon == std::string::npos ? token : token.substr(0, colon);
+      if (std::strtoull(hash_part.c_str(), nullptr, 16) == hash) {
+        if (colon == std::string::npos) {
+          return true;  // No slot list - all slots.
+        }
+        size_t p = colon + 1;
+        while (p < token.size()) {
+          size_t q = token.find('+', p);
+          if (q == std::string::npos) {
+            q = token.size();
+          }
+          if (q > p && std::strtoul(token.substr(p, q - p).c_str(), nullptr, 10) == tfetch_index) {
+            return true;
+          }
+          p = q + 1;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 
 void SpirvShaderTranslator::ProcessVertexFetchInstruction(
     const ParsedVertexFetchInstruction& instr) {
@@ -751,6 +807,21 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
       }
     }
 
+    // For a resolution-scaled, position-derived 2D sample in a pixel shader that
+    // uses PsParamGen (AC6's deferred restore passes), the guest de-swizzle runs
+    // on integer guest pixels (see the param_gen floor in
+    // StartFragmentShaderInMain) and so samples the guest-texel centre, losing
+    // the host sub-pixel. Re-add it after the coordinate has been normalized so
+    // the sample lands on the exact host texel - true resolution-scaled detail.
+    // Port of dxbc_translator_fetch.cpp; without it the cvar is inert here.
+    const bool apply_host_subpixel_correction =
+        instr.opcode == ucode::FetchOpcode::kTextureFetch &&
+        !instr.attributes.unnormalized_coordinates &&
+        instr.dimension == xenos::FetchOpDimension::k2D && is_pixel_shader() &&
+        !is_depth_only_fragment_shader_ && GetPsParamGenInterpolator() != UINT32_MAX &&
+        (draw_resolution_scale_x_ > 1 || draw_resolution_scale_y_ > 1) &&
+        REXCVAR_GET(param_gen_host_subpixel_restore);
+
     // Fetch constant word usage:
     // - 2: Size (needed only once).
     // - 3: Exponent adjustment (needed only once).
@@ -766,6 +837,39 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
     // 3D: X - width, Y - height, Z - depth.
     uint32_t size_needed_components = 0b000;
     bool data_is_3d_needed = false;
+
+    // AC6 de-swizzle neutralisation (port of the DXBC path in
+    // dxbc_translator_fetch.cpp). Some guest post-process passes re-implement the
+    // EDRAM tiling swizzle on their source, which is only correct while the source
+    // stays tiled. The texture cache detiles everything to linear, so that
+    // arithmetic becomes a wrong texel permutation - here the resulting UVs leave
+    // [0, 1] and clamp to the black border, which is why the world reads as black
+    // on this backend while the D3D12 path (which has this fix) is fine.
+    //
+    // For an allowlisted shader, replace the coordinate with the identity
+    // host-texel UV so the pass copies its source 1:1.
+    bool apply_deswizzle_identity = false;
+    if (instr.opcode == ucode::FetchOpcode::kTextureFetch &&
+        !instr.attributes.unnormalized_coordinates &&
+        instr.dimension == xenos::FetchOpDimension::k2D && is_pixel_shader() &&
+        GetSpirvShaderModification().pixel.param_gen_enable &&
+        input_fragment_coordinates_ != spv::NoResult) {
+      const std::string& neutralize_hashes = REXCVAR_GET(ac6_neutralize_deswizzle_hashes);
+      apply_deswizzle_identity =
+          !neutralize_hashes.empty() &&
+          Ac6UcodeHashSlotInList(current_shader().ucode_data_hash(), fetch_constant_index,
+                                 neutralize_hashes);
+    }
+    if (apply_deswizzle_identity) {
+      // The identity UV divides by the guest size, so both components must be
+      // loaded even when the original coordinate maths would not have needed them.
+      size_needed_components |= 0b011;
+    }
+    if (apply_host_subpixel_correction) {
+      // Same: the guest width and height convert the host sub-pixel offset into
+      // normalized texture space.
+      size_needed_components |= 0b011;
+    }
     if (instr.opcode == ucode::FetchOpcode::kGetTextureWeights) {
       // Size needed for denormalization for coordinate lerp factor.
       // FIXME(Triang3l): Currently disregarding the LOD completely in
@@ -1100,6 +1204,69 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
           }
         }
       }
+      if (apply_host_subpixel_correction) {
+        // The coordinate now samples the guest-texel centre (host texel
+        // scale * swizzle(g) + scale / 2). Shift it to the current host
+        // sub-pixel so it samples host texel scale * swizzle(g) + s - the
+        // host-resolution swizzle - landing on an exact texel centre.
+        assert_true(input_fragment_coordinates_ != spv::NoResult);
+        assert_true(texture_resolution_scaled != spv::NoResult);
+        for (uint32_t i = 0; i < 2; ++i) {
+          const uint32_t axis_scale = i ? draw_resolution_scale_y_ : draw_resolution_scale_x_;
+          if (axis_scale <= 1) {
+            continue;
+          }
+          // host_subpixel = uint(gl_FragCoord[i]) % scale.
+          id_vector_temp_.clear();
+          id_vector_temp_.push_back(builder_->makeIntConstant(int(i)));
+          spv::Id position_component = builder_->createLoad(
+              builder_->createAccessChain(spv::StorageClassInput, input_fragment_coordinates_,
+                                          id_vector_temp_),
+              spv::NoPrecision);
+          spv::Id host_subpixel = builder_->createUnaryOp(
+              spv::OpConvertUToF, type_float_,
+              builder_->createBinOp(
+                  spv::OpUMod, type_uint_,
+                  builder_->createUnaryOp(spv::OpConvertFToU, type_uint_, position_component),
+                  builder_->makeUintConstant(axis_scale)));
+          // delta = (host_subpixel - (scale - 1) / 2) / (guest_size * scale).
+          spv::Id delta = builder_->createNoContractionBinOp(
+              spv::OpFAdd, type_float_, host_subpixel,
+              builder_->makeFloatConstant(-(float(axis_scale) - 1.0f) * 0.5f));
+          assert_true(size[i] != spv::NoResult);
+          delta = builder_->createNoContractionBinOp(spv::OpFDiv, type_float_, delta, size[i]);
+          delta = builder_->createNoContractionBinOp(spv::OpFMul, type_float_, delta,
+                                                     const_texture_resolution_scale_reciprocal[i]);
+          // Only resolution-scaled textures are stored at host resolution.
+          coordinates[i] = builder_->createTriOp(
+              spv::OpSelect, type_float_, texture_resolution_scaled,
+              builder_->createNoContractionBinOp(spv::OpFAdd, type_float_, coordinates[i], delta),
+              coordinates[i]);
+        }
+      }
+      if (apply_deswizzle_identity) {
+        // coordinates[0..1] currently hold the guest's de-swizzled coordinate,
+        // computed for tiled data that the texture cache has already detiled.
+        // Overwrite it with the identity host-texel UV:
+        //   uv = gl_FragCoord.xy / (guest_size * draw_resolution_scale)
+        // Unconditional within an allowlisted shader - there is no swizzled
+        // source this could break. Mirrors dxbc_translator_fetch.cpp.
+        const float resolution_scale[2] = {float(draw_resolution_scale_x_),
+                                           float(draw_resolution_scale_y_)};
+        for (uint32_t i = 0; i < 2; ++i) {
+          assert_true(size[i] != spv::NoResult);
+          spv::Id host_size = size[i];
+          if (resolution_scale[i] != 1.0f) {
+            host_size = builder_->createNoContractionBinOp(
+                spv::OpFMul, type_float_, host_size,
+                builder_->makeFloatConstant(resolution_scale[i]));
+          }
+          spv::Id frag_coord_component = builder_->createCompositeExtract(
+              builder_->createLoad(input_fragment_coordinates_, spv::NoPrecision), type_float_, i);
+          coordinates[i] = builder_->createNoContractionBinOp(spv::OpFDiv, type_float_,
+                                                             frag_coord_component, host_size);
+        }
+      }
       if (instr.dimension == xenos::FetchOpDimension::k3DOrStacked) {
         spv::Id& z_coordinate_ref = coordinates[2];
         spv::Id z_offset =
@@ -1429,6 +1596,21 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
             spv::NoPrecision);
         spv::Id fetch_constant_word_4_signed =
             builder_->createUnaryOp(spv::OpBitcast, type_int_, fetch_constant_word_4);
+
+        // Load the fetch constant word 3 as well - it holds exp_adjust
+        // (dword_3 +13), needed for the result exponent bias below.
+        id_vector_temp_.clear();
+        id_vector_temp_.push_back(const_int_0_);
+        id_vector_temp_.push_back(
+            builder_->makeIntConstant(int((fetch_constant_word_0_index + 3) >> 2)));
+        id_vector_temp_.push_back(
+            builder_->makeIntConstant(int((fetch_constant_word_0_index + 3) & 3)));
+        spv::Id fetch_constant_word_3 = builder_->createLoad(
+            builder_->createAccessChain(spv::StorageClassUniform, uniform_fetch_constants_,
+                                        id_vector_temp_),
+            spv::NoPrecision);
+        spv::Id fetch_constant_word_3_signed =
+            builder_->createUnaryOp(spv::OpBitcast, type_int_, fetch_constant_word_3);
 
         // Accumulate the explicit LOD (or LOD bias) sources (in D3D11.3
         // specification order: specified LOD + sampler LOD bias + instruction
@@ -2036,10 +2218,15 @@ void SpirvShaderTranslator::ProcessTextureFetchInstruction(
         }
 
         // Apply the exponent bias from the bits 13:18 of the fetch constant
-        // word 4.
+        // word 3 (xe_gpu_texture_fetch_t::exp_adjust, dword_3 +13). This was
+        // previously read from word 4, whose bits 13:18 fall inside lod_bias
+        // (dword_4 +12, 10 bits), so a nonzero LOD bias was applied as an
+        // exponent bias and scaled every fetched texel by a power of two - for
+        // AC6 by 2^-8, crushing the composite to black. The DXBC translator
+        // reads word 3 here, which is why this only affected Vulkan.
         spv::Id result_exponent_bias = builder_->createBinBuiltinCall(
             type_float_, ext_inst_glsl_std_450_, GLSLstd450Ldexp, const_float_1_,
-            builder_->createTriOp(spv::OpBitFieldSExtract, type_int_, fetch_constant_word_4_signed,
+            builder_->createTriOp(spv::OpBitFieldSExtract, type_int_, fetch_constant_word_3_signed,
                                   builder_->makeUintConstant(13), builder_->makeUintConstant(6)));
         {
           uint32_t result_remaining_components = used_result_nonzero_components;

--- a/thirdparty/rexglue-sdk/src/graphics/pipeline/texture/cache.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/pipeline/texture/cache.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <mutex>
 #include <utility>
 
 #include <rex/assert.h>
@@ -430,6 +431,14 @@ bool TextureCache::CommitPreparedTextureLoad(const PendingTextureLoad& pending_l
 
   if (!LoadTextureDataFromResidentMemoryImpl(texture, pending_load.load_base,
                                              pending_load.load_mips)) {
+    static bool logged = false;
+    if (!logged) {
+      logged = true;
+      REXGPU_ERROR("Texture upload failed: base_page={:05X} {}x{} fmt={} scaled={}",
+                   uint32_t(texture_key.base_page), texture_key.GetWidth(),
+                   texture_key.GetHeight(), uint32_t(texture_key.format),
+                   uint32_t(texture_key.scaled_resolve));
+    }
     return false;
   }
 

--- a/thirdparty/rexglue-sdk/src/graphics/util/draw_extent_estimator.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/util/draw_extent_estimator.cpp
@@ -24,7 +24,12 @@
 #include <rex/memory.h>
 #include <rex/ui/graphics_util.h>
 
-REXCVAR_DEFINE_BOOL(execute_unclipped_draw_vs_on_cpu, false, "GPU",
+// Upstream defaults this to true (see the reference definition below). With it
+// off, unclipped draws get no vertex extent estimate, so height_used falls back
+// to the full render target height - a single depth-only unclipped draw then
+// claims all 2048 EDRAM tiles and takes ownership of every range, and anything
+// resolving from those tiles afterwards inherits depth data instead of colour.
+REXCVAR_DEFINE_BOOL(execute_unclipped_draw_vs_on_cpu, true, "GPU",
                     "Execute unclipped draw vertex shader on CPU");
 
 REXCVAR_DEFINE_BOOL(execute_unclipped_draw_vs_on_cpu_with_scissor, false, "GPU",

--- a/thirdparty/rexglue-sdk/src/graphics/vulkan/command_processor.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/vulkan/command_processor.cpp
@@ -47,6 +47,9 @@
 #include <rex/ui/vulkan/util.h>
 
 #include "../../../../../src/ac6_backend_fixes/ac6_backend_hooks.h"
+#include "../../../../../src/ac6_backend_fixes/ac6_fullres_effects.h"
+#include "../../../../../src/ac6_backend_fixes/ac6_widescreen.h"
+#include "../../../../../src/render_hooks.h"
 
 // Legacy backend compatibility aliases for shared readback controls.
 REXCVAR_DEFINE_BOOL(vulkan_readback_resolve, false, "GPU/Vulkan",
@@ -612,6 +615,59 @@ void VulkanCommandProcessor::InvalidateGpuMemory() {
   }
 }
 
+bool VulkanCommandProcessor::AC6TerrainHdEnsureRing() {
+  if (ac6_hd_ring_phys_ == UINT32_MAX) {
+    return false;
+  }
+  if (ac6_hd_ring_phys_) {
+    return true;
+  }
+  // Build the synthetic ring: for each of the group's 4 fans (patch bases
+  // (0,0), (2,0), (0,2), (2,2) in (row, col) cells), slots (10f+1+k) mod 40
+  // hold sample k of the fan's full 3x3 grid (row-major; the +1 is the
+  // shader's ring phase). Slots 0/10/20/30 are never referenced. The ring is
+  // game-global - the authored one is byte-identical across maps.
+  static const uint16_t kPatchBase[4][2] = {{0, 0}, {2, 0}, {0, 2}, {2, 2}};
+  uint16_t entries[80] = {};
+  for (uint32_t f = 0; f < 4; ++f) {
+    for (uint32_t k = 0; k < 9; ++k) {
+      uint32_t slot = (10 * f + 1 + k) % 40;
+      entries[slot * 2 + 0] = uint16_t(kPatchBase[f][0] + k / 3);  // row
+      entries[slot * 2 + 1] = uint16_t(kPatchBase[f][1] + k % 3);  // col
+    }
+  }
+  memory::Memory* memory = kernel_state_->memory();
+  uint32_t ring_virt = memory->SystemHeapAlloc(sizeof(entries), 256, memory::kSystemHeapPhysical);
+  if (!ring_virt) {
+    REXGPU_ERROR("AC6 HD terrain: failed to allocate the synthetic ring table");
+    ac6_hd_ring_phys_ = UINT32_MAX;
+    return false;
+  }
+  uint32_t* ring_host = memory->TranslateVirtual<uint32_t*>(ring_virt);
+  const uint32_t* words = reinterpret_cast<const uint32_t*>(entries);
+  for (uint32_t i = 0; i < sizeof(entries) / sizeof(uint32_t); ++i) {
+    // Guest vertex fetch tables are 8-in-32 big-endian.
+    ring_host[i] = rex::byte_swap(words[i]);
+  }
+  ac6_hd_ring_phys_ = memory->GetPhysicalAddress(ring_virt);
+  if (ac6_hd_ring_phys_ == UINT32_MAX) {
+    REXGPU_ERROR("AC6 HD terrain: synthetic ring allocation has no physical address");
+    return false;
+  }
+  REXGPU_INFO("AC6 HD terrain: synthetic ring at guest 0x{:08X} (virtual 0x{:08X})",
+              ac6_hd_ring_phys_, ring_virt);
+  return true;
+}
+
+std::pair<uint32_t, uint32_t> VulkanCommandProcessor::VertexBufferMemoryInvalidationCallbackThunk(
+    void* context_ptr, uint32_t physical_address_start, uint32_t length, bool exact_range) {
+  // Runs on the writing (guest) thread - just flag; the GPU thread drops its
+  // cached vertex buffer states at the next draw.
+  auto command_processor = static_cast<VulkanCommandProcessor*>(context_ptr);
+  command_processor->vertex_buffer_memory_invalidated_.store(true, std::memory_order_release);
+  return std::make_pair(uint32_t(0), UINT32_MAX);
+}
+
 void VulkanCommandProcessor::InvalidateAllVertexBufferResidency() {
   vertex_buffers_in_sync_[0] = 0;
   vertex_buffers_in_sync_[1] = 0;
@@ -785,6 +841,21 @@ bool VulkanCommandProcessor::SetupContext() {
     return false;
   }
   InvalidateAllVertexBufferResidency();
+
+  // AC6 (ac6_fix_trails): the vertex-buffer residency shortcut assumes the
+  // guest does not rewrite vertex data in place at a fixed address (AC6's
+  // trail history ring does exactly that), so pages invalidated by the CPU
+  // would never be re-uploaded to the GPU copy.
+  if (REXCVAR_GET(ac6_fix_trails)) {
+    vertex_buffer_memory_invalidation_callback_handle_ =
+        memory_->RegisterPhysicalMemoryInvalidationCallback(
+            VertexBufferMemoryInvalidationCallbackThunk, this);
+  }
+
+  // AC6: start the ultrawide camera-aspect patcher (idles unless the
+  // ac6_widescreen cvar is enabled). Runs here rather than at app create
+  // because the toml - and so the cvar - is loaded by now.
+  ac6::WidescreenInit(memory_);
 
   const ui::vulkan::VulkanDevice* const vulkan_device = GetVulkanDevice();
   const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
@@ -2036,6 +2107,12 @@ void VulkanCommandProcessor::ShutdownContext() {
   render_target_cache_.reset();
 
   primitive_processor_.reset();
+
+  if (vertex_buffer_memory_invalidation_callback_handle_) {
+    memory_->UnregisterPhysicalMemoryInvalidationCallback(
+        vertex_buffer_memory_invalidation_callback_handle_);
+    vertex_buffer_memory_invalidation_callback_handle_ = nullptr;
+  }
 
   shared_memory_.reset();
 
@@ -3721,6 +3798,118 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t 
     }
     draw_util::AddMemExportRanges(regs, *pixel_shader, memexport_ranges_);
   }
+
+  // AC6: the world/effects compositor draws once per frame whenever the 3D
+  // world renders (never in the 2D front-end) - stamp it as the "gameplay
+  // world active" signal for the dynamic FPS pacing. The hash is of the guest
+  // microcode, so it is the same value the D3D12 backend matches on. Without
+  // this the signal never fires, AreTimingHooksActive() fails closed forever,
+  // and the whole FPS-unlock/physics-dt family is silently dead on Vulkan.
+  if (pixel_shader && pixel_shader->ucode_data_hash() == UINT64_C(0x17e5e4ac3e713245)) {
+    ac6::NotifyWorldCompositorDraw();
+  }
+
+  // AC6 full-res effects (the silhouette fix): the compositor mask is sampled
+  // by whichever cloud draw binds it, not necessarily the world compositor -
+  // so crop the mask fetch to the filled 640x360 quarter on every draw that
+  // reads it. No-op unless ac6_fullres_effects + ac6_fullres_mask_crop.
+  ac6::backend::FxCropCompositorMask(
+      vertex_shader ? vertex_shader->ucode_data_hash() : 0,
+      pixel_shader ? pixel_shader->ucode_data_hash() : 0,
+      &register_file_->values[XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0]);
+
+  // AC6 full-res effects (THE silhouette fix): the 2:1 silhouette downscaler
+  // samples 2*coord from its full-res input; doubling the fx buffers made its
+  // output 1280 wide, so it reads 0..2560 from a 1280-wide input -> the right
+  // half wraps -> 2x2 ghost planes. Restore JUST this draw's target to 640
+  // wide (hash-gated - no scene-wide effect). Must run before the render
+  // target and viewport state below is derived from these registers.
+  ac6::backend::FxFixDownscalerDraw(
+      pixel_shader ? pixel_shader->ucode_data_hash() : 0,
+      &register_file_->values[XE_GPU_REG_RB_SURFACE_INFO],
+      &register_file_->values[XE_GPU_REG_PA_CL_VPORT_XSCALE],
+      &register_file_->values[XE_GPU_REG_PA_CL_VPORT_YSCALE],
+      &register_file_->values[XE_GPU_REG_PA_CL_VPORT_XOFFSET],
+      &register_file_->values[XE_GPU_REG_PA_CL_VPORT_YOFFSET]);
+
+  // AC6 ultrawide: pre-squeeze the game's screen-space 2D transforms in the VS
+  // float constants so the presenter's fill-window stretch cancels out where
+  // the fill presentation is active. No-op unless ac6_widescreen +
+  // ac6_widescreen_ui.
+  // Sub-screen guest viewport (radar window, PiP inset): |x scale| is half the
+  // viewport width in guest pixels - well under the full 640.
+  float ac6_vp_xscale;
+  std::memcpy(&ac6_vp_xscale, &regs.values[XE_GPU_REG_PA_CL_VPORT_XSCALE],
+              sizeof(ac6_vp_xscale));
+  const float ac6_vp_xscale_abs = ac6_vp_xscale < 0.0f ? -ac6_vp_xscale : ac6_vp_xscale;
+  const bool ac6_sub_viewport = ac6_vp_xscale_abs >= 1.0f && ac6_vp_xscale_abs < 576.0f;
+  if (ac6::WidescreenPatchUiOrtho(&register_file_->values[XE_GPU_REG_SHADER_CONSTANT_000_X],
+                                  vertex_shader ? vertex_shader->ucode_data_hash() : 0,
+                                  ac6_sub_viewport)) {
+    // The Vulkan analogue of invalidating D3D12's vertex float cbuffer
+    // binding: drop the uploaded copy so the patched constants are re-written.
+    current_constant_buffers_up_to_date_ &=
+        ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferFloatVertex);
+  }
+
+  // AC6 ultrawide: narrow target-marker quads about their own centres so the
+  // fill-window stretch renders them square while the game-computed aim points
+  // stay put. The game draws them as a quad list of screen-space positions in
+  // a CPU-written arena, so the edit is made in guest memory here - before the
+  // vertex buffers are requested below - and is naturally transient (the arena
+  // is rewritten every frame).
+  if (vertex_shader && prim_type == xenos::PrimitiveType::kQuadList &&
+      ac6::WidescreenWantsMarkerQuadFix(vertex_shader->ucode_data_hash())) {
+    for (const Shader::VertexBinding& vb : vertex_shader->vertex_bindings()) {
+      if (vb.attributes.empty() || !vb.stride_words) {
+        continue;
+      }
+      xenos::xe_gpu_vertex_fetch_t vf = regs.GetVertexFetch(vb.fetch_constant);
+      if (vf.type != xenos::FetchConstantType::kVertex) {
+        continue;
+      }
+      uint32_t arena_base = vf.address << 2;
+      uint8_t* vertex_data = memory_->TranslatePhysical(arena_base);
+      if (!vertex_data) {
+        continue;
+      }
+      const uint8_t* index_data = nullptr;
+      bool indices_32bit = false;
+      if (index_buffer_info && index_buffer_info->guest_base) {
+        index_data = memory_->TranslatePhysical(index_buffer_info->guest_base);
+        indices_32bit = index_buffer_info->format == xenos::IndexFormat::kInt32;
+      }
+      // The position attribute is the one at offset 0 of the vertex.
+      ac6::WidescreenShrinkMarkerQuads(vertex_data, vb.stride_words * sizeof(uint32_t),
+                                       uint32_t(vb.attributes[0].fetch_instr.attributes.offset) *
+                                           sizeof(uint32_t),
+                                       index_data, indices_32bit, index_count, arena_base);
+    }
+  }
+
+  // AC6 HD terrain: the terrain vertex shader is fully data-driven, so a
+  // synthetic ring table (vertex fetch 95 redirect) plus a full-density fan
+  // emission make the unmodified shader draw every shipped height sample - no
+  // more T-junction cracks ("rifts"), and river beds render true.
+  {
+    bool ac6_hd = false;
+    if (REXCVAR_GET(ac6_terrain_hd) && prim_type == xenos::PrimitiveType::kTriangleFan) {
+      uint64_t vs_ucode_hash = vertex_shader->ucode_data_hash();
+      ac6_hd = (vs_ucode_hash == UINT64_C(0x042F34FADAD3F370) ||
+                vs_ucode_hash == UINT64_C(0xD113DCDC8F6AC408)) &&
+               AC6TerrainHdEnsureRing();
+    }
+    if (ac6_hd != ac6_hd_active_) {
+      // The effective vertex fetch constant 95 changes without a guest
+      // register write - drop the residency shortcut and the uploaded copy.
+      ac6_hd_active_ = ac6_hd;
+      vertex_buffers_in_sync_[95 >> 6] &= ~(uint64_t(1) << (95 & 63));
+      current_constant_buffers_up_to_date_ &=
+          ~(UINT32_C(1) << SpirvShaderTranslator::kConstantBufferFetch);
+    }
+    primitive_processor_->SetAc6TerrainFanHd(ac6_hd);
+  }
+
   reg::RB_DEPTHCONTROL normalized_depth_control = draw_util::GetNormalizedDepthControl(regs);
 
   uint32_t ps_param_gen_pos = UINT32_MAX;
@@ -3870,6 +4059,30 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t 
   uint32_t normalized_color_mask =
       pixel_shader ? draw_util::GetNormalizedColorMask(regs, pixel_shader->writes_color_targets())
                    : 0;
+  // AC6: the trail point-list pass writes no color components by the register
+  // state, so the normalized mask comes out empty and the draw is dropped -
+  // taking the condensation trails with it. Force RT0 color writes for exactly
+  // this shader pair.
+  if (pixel_shader && !normalized_color_mask &&
+      primitive_processing_result.guest_primitive_type == xenos::PrimitiveType::kPointList &&
+      regs.Get<reg::RB_MODECONTROL>().edram_mode == xenos::EdramMode::kColorDepth &&
+      vertex_shader->ucode_data_hash() == UINT64_C(0xC049A8C9E556F129) &&
+      pixel_shader->ucode_data_hash() == UINT64_C(0x2E372EA28CC404B7)) {
+    xenos::ColorRenderTargetFormat color_format =
+        regs.Get<reg::RB_COLOR_INFO>(reg::RB_COLOR_INFO::rt_register_indices[0]).color_format;
+    uint32_t format_component_count =
+        xenos::GetColorRenderTargetFormatComponentCount(color_format);
+    if (format_component_count) {
+      uint32_t format_component_mask = (uint32_t(1) << format_component_count) - 1;
+      normalized_color_mask = format_component_mask | (uint32_t(0b1111) & ~format_component_mask);
+      static bool logged_forced_ac6_trail_color_mask = false;
+      if (!logged_forced_ac6_trail_color_mask) {
+        logged_forced_ac6_trail_color_mask = true;
+        REXGPU_WARN("Forcing RT0 color writes for AC6 trail point-list pass VS {:016X} / PS {:016X}",
+                    vertex_shader->ucode_data_hash(), pixel_shader->ucode_data_hash());
+      }
+    }
+  }
 
   // Update the textures before most other work in the submission because
   // samplers depend on this (and in case of sampler overflow in a submission,
@@ -4020,6 +4233,14 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t 
   }
 
   // Ensure vertex buffers are resident.
+  if (vertex_buffer_memory_invalidated_.exchange(false, std::memory_order_acquire)) {
+    // The CPU wrote to watched GPU-visible memory since the last draw: cached
+    // vertex buffer states may cover invalidated pages, and the address-match
+    // shortcut below would skip the RequestRange re-upload forever. Drop the
+    // cache; the shared-memory validity fast path keeps still-valid buffers
+    // cheap to re-request.
+    InvalidateAllVertexBufferResidency();
+  }
   const Shader::ConstantRegisterMap& constant_map_vertex = vertex_shader->constant_register_map();
   for (uint32_t i = 0; i < rex::countof(constant_map_vertex.vertex_fetch_bitmap); ++i) {
     uint32_t vfetch_bits_remaining = constant_map_vertex.vertex_fetch_bitmap[i];
@@ -4032,6 +4253,12 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t 
         continue;
       }
       xenos::xe_gpu_vertex_fetch_t vfetch_constant = regs.GetVertexFetch(vfetch_index);
+      if (ac6_hd_active_ && vfetch_index == 95) {
+        // AC6 HD terrain: request residency for the synthetic ring, not for
+        // the authored ring the guest fetch constant points to.
+        vfetch_constant.address = ac6_hd_ring_phys_ >> 2;
+        vfetch_constant.size = 40;
+      }
       switch (vfetch_constant.type) {
         case xenos::FetchConstantType::kVertex:
           break;
@@ -5742,6 +5969,28 @@ void VulkanCommandProcessor::UpdateDynamicState(const draw_util::ViewportInfo& v
     viewport.width = 1.0f;
     viewport.height = 1.0f;
   }
+  // AC6 ultrawide: sub-viewport draws (radar window, PiP inset) are placed by
+  // their VIEWPORT rect, not their shader constants - shrinking their
+  // constants moves content around the viewport center instead of the screen
+  // center (the radar-misregistration bug). Shrink the viewport rect (and its
+  // scissor below) around the render target center instead; the
+  // constant-level patch skips these draws.
+  bool ac6_vp_scaled = false;
+  float ac6_vp_shrink = ac6::WidescreenViewportShrinkX();
+  if (ac6_vp_shrink != 1.0f && !normalized_depth_control.z_enable &&
+      (viewport.x >= 8.0f || viewport.y >= 8.0f)) {
+    // Placed UI insets only (radar window, PiP): inset-sized, depth disabled,
+    // and offset from the origin. Internal render-to-texture passes (half-res
+    // effects, shadows, EDRAM ops) are depth-enabled and/or origin-anchored -
+    // scaling THEIR viewports white-outs the world.
+    float ac6_full_width = 1280.0f * float(draw_resolution_scale_x);
+    if (viewport.width >= 1.0f && viewport.width < ac6_full_width * 0.35f) {
+      float ac6_center_x = ac6_full_width * 0.5f;
+      viewport.x = ac6_center_x + (viewport.x - ac6_center_x) * ac6_vp_shrink;
+      viewport.width *= ac6_vp_shrink;
+      ac6_vp_scaled = true;
+    }
+  }
   viewport.minDepth = viewport_info.z_min;
   viewport.maxDepth = viewport_info.z_max;
   SetViewport(viewport);
@@ -5758,6 +6007,20 @@ void VulkanCommandProcessor::UpdateDynamicState(const draw_util::ViewportInfo& v
   scissor_rect.offset.y = int32_t(scissor.offset[1]);
   scissor_rect.extent.width = scissor.extent[0];
   scissor_rect.extent.height = scissor.extent[1];
+  if (ac6_vp_scaled) {
+    // Same shrink the viewport just took, so the scissor keeps clipping the
+    // inset exactly. Vulkan stores offset+extent where D3D12 stores
+    // left/right, so both edges are moved and the width recomputed - never
+    // below zero, since extent is unsigned.
+    const float ac6_center_x = 1280.0f * float(draw_resolution_scale_x) * 0.5f;
+    const float left = float(scissor_rect.offset.x);
+    const float right = left + float(scissor_rect.extent.width);
+    const float new_left = ac6_center_x + (left - ac6_center_x) * ac6_vp_shrink;
+    const float new_right = ac6_center_x + (right - ac6_center_x) * ac6_vp_shrink + 0.5f;
+    scissor_rect.offset.x = int32_t(new_left);
+    scissor_rect.extent.width =
+        new_right > new_left ? uint32_t(new_right - float(scissor_rect.offset.x)) : 0u;
+  }
   SetScissor(scissor_rect);
 
   if (render_target_cache_->GetPath() == RenderTargetCache::Path::kHostRenderTargets) {
@@ -6590,6 +6853,13 @@ bool VulkanCommandProcessor::UpdateBindings(const VulkanShader* vertex_shader,
       }
       buffer_info.range = VkDeviceSize(kFetchConstantsSize);
       std::memcpy(mapping, &regs[XE_GPU_REG_SHADER_CONSTANT_FETCH_00_0], kFetchConstantsSize);
+      if (ac6_hd_active_) {
+        // AC6 HD terrain: point vertex fetch constant 95 at the synthetic
+        // ring. Address bits only - type, endian and size stay authentic.
+        uint32_t* fetch_dwords = reinterpret_cast<uint32_t*>(mapping);
+        fetch_dwords[95 * 2] =
+            (ac6_hd_ring_phys_ & ~uint32_t(3)) | (fetch_dwords[95 * 2] & uint32_t(3));
+      }
       current_constant_buffers_up_to_date_ |= UINT32_C(1)
                                               << SpirvShaderTranslator::kConstantBufferFetch;
     }

--- a/thirdparty/rexglue-sdk/src/graphics/vulkan/deferred_command_buffer.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/vulkan/deferred_command_buffer.cpp
@@ -156,6 +156,16 @@ void DeferredCommandBuffer::Execute(VkCommandBuffer command_buffer) {
                 rex::align(sizeof(ArgsVkCopyBufferToImage), alignof(VkBufferImageCopy))));
       } break;
 
+      case Command::kVkCopyImageToBuffer: {
+        auto& args = *reinterpret_cast<const ArgsVkCopyImageToBuffer*>(stream);
+        dfn.vkCmdCopyImageToBuffer(
+            command_buffer, args.src_image, args.src_image_layout, args.dst_buffer,
+            args.region_count,
+            reinterpret_cast<const VkBufferImageCopy*>(
+                reinterpret_cast<const uint8_t*>(stream) +
+                rex::align(sizeof(ArgsVkCopyImageToBuffer), alignof(VkBufferImageCopy))));
+      } break;
+
       case Command::kVkCopyQueryPoolResults: {
         auto& args = *reinterpret_cast<const ArgsVkCopyQueryPoolResults*>(stream);
         dfn.vkCmdCopyQueryPoolResults(command_buffer, args.query_pool, args.first_query,

--- a/thirdparty/rexglue-sdk/src/graphics/vulkan/pipeline_cache.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/vulkan/pipeline_cache.cpp
@@ -1246,6 +1246,17 @@ bool VulkanPipelineCache::TranslateAnalyzedShader(SpirvShaderTranslator& transla
     return false;
   }
 
+  // Dump shader files if desired. The shared translator already dumps the guest
+  // microcode; the translated binary is per-backend, and only the D3D12
+  // pipeline cache had this, so dump_shaders produced no SPIR-V at all.
+  if (!REXCVAR_GET(dump_shaders).empty()) {
+    bool edram_fsi_used =
+        render_target_cache_.GetPath() == RenderTargetCache::Path::kPixelShaderInterlock;
+    translation.Dump(REXCVAR_GET(dump_shaders), (shader.type() == xenos::ShaderType::kPixel)
+                                                    ? (edram_fsi_used ? "vulkan_fsi" : "vulkan_rtv")
+                                                    : "vulkan");
+  }
+
   // TODO(Triang3l): Log that the shader has been successfully translated in
   // common code.
 

--- a/thirdparty/rexglue-sdk/src/graphics/vulkan/render_target_cache.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/vulkan/render_target_cache.cpp
@@ -3937,6 +3937,16 @@ VkShaderModule VulkanRenderTargetCache::GetTransferShader(TransferShaderKey key)
                                         builder.makeUintConstant(8), builder.makeUintConstant(24));
         }
       }
+    } else if (mode.output == TransferOutput::kStencilBit && source_stencil[0] != spv::NoResult) {
+      // A stencil-bit transfer from a depth/stencil source binds only the
+      // stencil texture - the depth is not needed and deliberately not bound -
+      // so neither branch above runs and `packed` is left unset. The kill below
+      // only discards a sample when its bit is clear, and it is skipped
+      // entirely when `packed` is NoResult, so every sample would keep its bit
+      // and the destination stencil would come out 0xFF everywhere regardless
+      // of the source. Supply the stencil, which is all the kill needs, in bits
+      // 0:7.
+      packed = source_stencil[0];
     }
     switch (mode.output) {
       case TransferOutput::kColor: {
@@ -5328,6 +5338,21 @@ void VulkanRenderTargetCache::PerformTransfersAndResolveClears(
         const VkPipeline* transfer_pipelines = GetTransferPipelines(
             TransferPipelineKey(transfer_render_pass_key, transfer_shader_key));
         if (!transfer_pipelines) {
+          // This skip is otherwise silent, and a transfer that can never be
+          // built leaves the destination render target untouched (black).
+          static bool logged = false;
+          if (!logged) {
+            logged = true;
+            REXGPU_ERROR(
+                "No transfer pipeline: mode={} src_msaa={} dest_msaa={} src_fmt={} dest_fmt={} "
+                "rp_msaa={}",
+                uint32_t(transfer_shader_key.mode),
+                uint32_t(transfer_shader_key.source_msaa_samples),
+                uint32_t(transfer_shader_key.dest_msaa_samples),
+                uint32_t(transfer_shader_key.source_resource_format),
+                uint32_t(transfer_shader_key.dest_resource_format),
+                uint32_t(transfer_render_pass_key.msaa_samples));
+          }
           continue;
         }
         command_processor_.BindExternalGraphicsPipeline(transfer_pipelines[0]);

--- a/thirdparty/rexglue-sdk/src/graphics/vulkan/texture_cache.cpp
+++ b/thirdparty/rexglue-sdk/src/graphics/vulkan/texture_cache.cpp
@@ -33,6 +33,10 @@
 #include <rex/ui/vulkan/ui_samplers.h>
 #include <rex/ui/vulkan/util.h>
 
+#include "../../../../../src/ac6_backend_fixes/ac6_widescreen.h"
+
+REXCVAR_DECLARE(bool, ac6_widescreen);
+
 REXCVAR_DEFINE_BOOL(non_seamless_cube_map, false, "GPU", "Use non-seamless cube map sampling");
 
 namespace rex::graphics::vulkan {
@@ -1033,6 +1037,34 @@ VkImageView VulkanTextureCache::RequestSwapTexture(uint32_t& width_scaled_out,
   // Only texture->key, not the result of BindingInfoFromFetchConstant, contains
   // whether the texture is scaled.
   key = texture->key();
+
+  // AC6 ultrawide: drives the mode-classified presentation - in-mission GPU
+  // frames fill the window, everything else (the whole front end, and
+  // CPU-written frames like FMV or loading images even in-mission) presents
+  // letterboxed at 16:9. The page query and its log only matter (and only
+  // cost) with the feature on; the notify itself early-outs when disabled.
+  {
+    bool gpu_composed = false;
+    if (REXCVAR_GET(ac6_widescreen)) {
+      texture_util::TextureGuestLayout swap_layout = key.GetGuestLayout();
+      uint32_t swap_extent = swap_layout.base.level_data_extent_bytes;
+      gpu_composed =
+          swap_extent && shared_memory().IsAnyPageGpuWritten(key.base_page << 12, swap_extent);
+      static uint32_t ac6_last_swap_state = UINT32_MAX;
+      static uint32_t ac6_swap_state_logs = 0;
+      uint32_t ac6_swap_state = (uint32_t(key.base_page) << 1) | (gpu_composed ? 1u : 0u);
+      if (ac6_swap_state != ac6_last_swap_state) {
+        ac6_last_swap_state = ac6_swap_state;
+        if (ac6_swap_state_logs < 32) {
+          ++ac6_swap_state_logs;
+          REXGPU_ERROR("[AC6-SWAP] frontbuffer base_page={:05X} gpu_written={} extent=0x{:X}",
+                       uint32_t(key.base_page), gpu_composed ? 1 : 0, swap_extent);
+        }
+      }
+    }
+    ac6::WidescreenNotifySwapSource(gpu_composed, true);
+  }
+
   if (width_unscaled_out) {
     *width_unscaled_out = key.GetWidth();
   }
@@ -1232,11 +1264,27 @@ bool VulkanTextureCache::LoadTextureDataFromResidentMemoryImpl(Texture& texture,
       host_format_is_signed ? host_format_pair.format_signed : host_format_pair.format_unsigned;
   LoadShaderIndex load_shader = host_format.load_shader;
   if (load_shader == kLoadShaderIndexUnknown) {
+    // Logged once: this aborts the texture load, and a silent abort is very
+    // hard to trace back from the visual result.
+    static bool logged = false;
+    if (!logged) {
+      logged = true;
+      REXGPU_ERROR("No load shader for texture: base_page={:05X} fmt={} signed={} scaled={}",
+                   uint32_t(texture_key.base_page), uint32_t(texture_key.format),
+                   host_format_is_signed ? 1 : 0, uint32_t(texture_key.scaled_resolve));
+    }
     return false;
   }
   VkPipeline pipeline = texture_key.scaled_resolve ? load_pipelines_scaled_[load_shader]
                                                    : load_pipelines_[load_shader];
   if (pipeline == VK_NULL_HANDLE) {
+    static bool logged = false;
+    if (!logged) {
+      logged = true;
+      REXGPU_ERROR("Null load pipeline for texture: base_page={:05X} fmt={} load_shader={} scaled={}",
+                   uint32_t(texture_key.base_page), uint32_t(texture_key.format),
+                   uint32_t(load_shader), uint32_t(texture_key.scaled_resolve));
+    }
     return false;
   }
   const LoadShaderInfo& load_shader_info = GetLoadShaderInfo(load_shader);

--- a/thirdparty/rexglue-sdk/src/input/sdl/sdl_input_driver.cpp
+++ b/thirdparty/rexglue-sdk/src/input/sdl/sdl_input_driver.cpp
@@ -16,6 +16,7 @@
 #include <rex/assert.h>
 #include <rex/chrono/clock.h>
 #include <rex/cvar.h>
+#include <rex/filesystem.h>
 #include <rex/input/flags.h>
 #include <rex/input/sdl/sdl_input_driver.h>
 #include <rex/logging.h>
@@ -39,6 +40,27 @@ void WarnOrphanEvent(const char* handler, SDL_JoystickID instance_id) {
     REXLOG_WARN("SDL {}: dropped event for unknown gamepad instance {} ({} dropped so far).",
                 handler, instance_id, n);
   }
+}
+
+// The mappings cvar is normally a bare filename. Resolving it against the CWD
+// alone only works when the game happens to be launched from its own directory,
+// so try next to the executable first - that is where the file ships - and fall
+// back to the CWD. Returns an empty string when neither candidate exists.
+std::string ResolveMappingsPath(const std::string& configured) {
+  const std::filesystem::path configured_path(configured);
+  if (configured_path.is_absolute()) {
+    return std::filesystem::exists(configured_path) ? configured : std::string();
+  }
+
+  std::error_code ec;
+  const auto next_to_exe = rex::filesystem::GetExecutableFolder() / configured_path;
+  if (std::filesystem::exists(next_to_exe, ec)) {
+    return rex::path_to_utf8(next_to_exe);
+  }
+  if (std::filesystem::exists(configured_path, ec)) {
+    return configured;
+  }
+  return std::string();
 }
 }  // namespace
 
@@ -99,30 +121,35 @@ void SDLInputDriver::OnWindowAvailable(rex::ui::Window* window) {
           },
           this);
 
-      // Initialize game controller subsystem
-      if (!SDL_InitSubSystem(SDL_INIT_GAMEPAD)) {
+      // Load custom controller mappings before the gamepad subsystem enumerates,
+      // so the initial device-added burst is already mapping-aware.
+      if (!REXCVAR_GET(hid_mappings_file).empty()) {
+        const auto mappings_path = ResolveMappingsPath(REXCVAR_GET(hid_mappings_file));
+        if (mappings_path.empty()) {
+          REXLOG_WARN("SDL GameControllerDB: file '{}' does not exist.",
+                      REXCVAR_GET(hid_mappings_file));
+        } else {
+          auto mappings_result = SDL_AddGamepadMappingsFromFile(mappings_path.c_str());
+          if (mappings_result < 0) {
+            REXLOG_ERROR("SDL GameControllerDB: error loading file '{}': {}.", mappings_path,
+                         SDL_GetError());
+          } else {
+            REXLOG_INFO("SDL GameControllerDB: loaded {} mappings from '{}'.", mappings_result,
+                        mappings_path);
+          }
+        }
+      }
+
+      // Initialize game controller subsystem. SDL_INIT_JOYSTICK is requested
+      // alongside it purely so unmapped sticks still raise a device-added event:
+      // without a mapping SDL never reports them as gamepads, and they would
+      // otherwise disappear with nothing logged.
+      if (!SDL_InitSubSystem(SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK)) {
         REXLOG_ERROR("SDL: Failed to init gamecontroller subsystem: {}", SDL_GetError());
         return;
       }
       SDL_Gamepad_initialized_ = true;
 
-      // Load custom controller mappings if available
-      if (!REXCVAR_GET(hid_mappings_file).empty()) {
-        std::filesystem::path mappings_path(REXCVAR_GET(hid_mappings_file));
-        if (!std::filesystem::exists(mappings_path)) {
-          REXLOG_WARN("SDL GameControllerDB: file '{}' does not exist.",
-                      REXCVAR_GET(hid_mappings_file));
-        } else {
-          auto mappings_result =
-              SDL_AddGamepadMappingsFromFile(REXCVAR_GET(hid_mappings_file).c_str());
-          if (mappings_result < 0) {
-            REXLOG_ERROR("SDL GameControllerDB: error loading file '{}': {}.",
-                         REXCVAR_GET(hid_mappings_file), mappings_result);
-          } else {
-            REXLOG_INFO("SDL GameControllerDB: loaded {} mappings.", mappings_result);
-          }
-        }
-      }
       REXLOG_INFO("SDL input driver initialized successfully");
     });
   }
@@ -438,6 +465,9 @@ void SDLInputDriver::ProcessEventLocked(const SDL_Event& event) {
     case SDL_EVENT_GAMEPAD_REMOVED:
       OnControllerDeviceRemovedLocked(event);
       break;
+    case SDL_EVENT_JOYSTICK_ADDED:
+      OnJoystickDeviceAddedLocked(event);
+      break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
       OnControllerDeviceAxisMotionLocked(event);
       break;
@@ -450,15 +480,37 @@ void SDLInputDriver::ProcessEventLocked(const SDL_Event& event) {
   }
 }
 
+void SDLInputDriver::OnJoystickDeviceAddedLocked(const SDL_Event& event) {
+  const auto instance_id = event.jdevice.which;
+  if (SDL_IsGamepad(instance_id)) {
+    // It has a mapping, so SDL_EVENT_GAMEPAD_ADDED covers it.
+    return;
+  }
+
+  // Without a mapping SDL never surfaces the device through the gamepad API,
+  // which is where every other code path here gets its controllers from. Name it
+  // loudly with the GUID a gamecontrollerdb entry has to be keyed on, otherwise
+  // the device is indistinguishable from one that was never plugged in.
+  char guid[33] = {};
+  SDL_GUIDToString(SDL_GetJoystickGUIDForID(instance_id), guid, sizeof(guid));
+  const char* name = SDL_GetJoystickNameForID(instance_id);
+
+  REXLOG_WARN(
+      "SDL: joystick \"{}\" (GUID {}, VendorID(0x{:04X}), ProductID(0x{:04X})) has no gamepad "
+      "mapping and will be ignored. Add a line for that GUID to '{}' to use it.",
+      name ? name : "<unnamed>", guid, SDL_GetJoystickVendorForID(instance_id),
+      SDL_GetJoystickProductForID(instance_id), REXCVAR_GET(hid_mappings_file));
+}
+
 void SDLInputDriver::OnControllerDeviceAddedLocked(const SDL_Event& event) {
   // Open the controller.
-  const auto controller = SDL_OpenGamepad(event.cdevice.which);
+  const auto controller = SDL_OpenGamepad(event.gdevice.which);
   if (!controller) {
     // Transient open failures are real on hot-plug (e.g. a Bluetooth pad that
     // reconnects before the stack has settled). The device is simply not
     // added; it gets a fresh chance on its next SDL_EVENT_GAMEPAD_ADDED.
     REXLOG_WARN("SDL OnControllerDeviceAdded: SDL_OpenGamepad failed for device {}: {}",
-                event.cdevice.which, SDL_GetError());
+                event.gdevice.which, SDL_GetError());
     return;
   }
   REXLOG_INFO(
@@ -508,7 +560,7 @@ void SDLInputDriver::OnControllerDeviceAddedLocked(const SDL_Event& event) {
 
 void SDLInputDriver::OnControllerDeviceRemovedLocked(const SDL_Event& event) {
   // Find the disconnected gamecontroller and close it.
-  auto idx = GetControllerIndexFromInstanceID(event.cdevice.which);
+  auto idx = GetControllerIndexFromInstanceID(event.gdevice.which);
   if (idx) {
     SDL_CloseGamepad(controllers_.at(*idx).sdl);
     controllers_.at(*idx) = {};

--- a/thirdparty/rexglue-sdk/src/native/audio/audio_runtime.cpp
+++ b/thirdparty/rexglue-sdk/src/native/audio/audio_runtime.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <limits>
@@ -29,7 +30,7 @@ REXCVAR_DEFINE_STRING(audio_backend, "sdl", "Audio", "Audio backend: sdl")
     .allowed({"sdl"})
 #endif
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
-REXCVAR_DEFINE_INT32(audio_max_queue_depth, 8, "Audio",
+REXCVAR_DEFINE_INT32(audio_max_queue_depth, 16, "Audio",
                      "Maximum queued render-driver frames per client");
 REXCVAR_DEFINE_INT32(audio_callback_low_water_frames, 1, "Audio",
                      "Request a new guest callback when the runtime queue falls to this depth");
@@ -90,7 +91,21 @@ uint32_t StartupMaxCallbackLeadFrames() {
 uint32_t EffectiveCallbackTargetQueueDepth(const AudioClientState& client) {
   const uint32_t requested_target = CallbackTargetQueueDepth();
   const uint32_t driver_target = client.driver ? client.driver->queue_target_frames() : 1;
-  return std::clamp(std::max(requested_target, driver_target), 1u, QueueDepthLimit());
+  const uint32_t wanted = std::max(requested_target, driver_target);
+  const uint32_t limit = QueueDepthLimit();
+  if (wanted > limit) {
+    // Clamping below what the driver needs to cover one device period means a
+    // guaranteed underrun on every callback, so say so instead of silently
+    // capping it. Latched: this is evaluated on every worker iteration.
+    static std::atomic<bool> warned{false};
+    if (!warned.exchange(true, std::memory_order_relaxed)) {
+      REXAPU_WARN(
+          "Audio queue target {} clamped to audio_max_queue_depth={}; the host device period "
+          "cannot be filled and will underrun. Raise audio_max_queue_depth.",
+          wanted, limit);
+    }
+  }
+  return std::clamp(wanted, 1u, limit);
 }
 
 uint32_t EffectiveCallbackLowWaterFrames(const AudioClientState& client) {
@@ -185,6 +200,25 @@ bool ShouldThrottleStartupCallback(const AudioClientState& client,
   // queued render-driver frame. Host-injected underrun silence should advance
   // tic timing, but it must not release callback pacing on its own.
   if (QueuedPlaybackObserved(client)) {
+    return false;
+  }
+
+  // Safety valve. The latch above is released only by the host draining a real
+  // queued frame; if that never happens the title stays pinned at one callback
+  // per iteration indefinitely. Give up after a bounded number of throttled
+  // passes so a starved host cannot wedge startup. This should never fire once
+  // the queue is sized to the device period - if it does, something else is
+  // keeping real frames from reaching the host.
+  constexpr uint32_t kMaxStartupThrottleIterations = 200;  // ~1s at the 5ms worker tick
+  if (client.telemetry.callback_throttle_count >= kMaxStartupThrottleIterations) {
+    // The counter stops advancing once the valve opens, so latch the warning
+    // rather than keying it off the count.
+    static std::atomic<bool> warned{false};
+    if (!warned.exchange(true, std::memory_order_relaxed)) {
+      REXAPU_WARN("Audio startup pacing released by safety valve after {} throttled passes "
+                  "with no real frame drained; host audio may be starved",
+                  kMaxStartupThrottleIterations);
+    }
     return false;
   }
 
@@ -511,6 +545,11 @@ bool AudioRuntime::SubmitFrame(const size_t index, const uint32_t samples_ptr) {
   trace_buffer_.Record(AudioTraceSubsystem::kCore, AudioTraceEventType::kFrameSubmitted,
                        static_cast<uint32_t>(index), samples_ptr, client.telemetry.queued_depth,
                        static_cast<uint32_t>(frame.sequence_number));
+  // Called with mutex_ still held, which the host audio callback also takes.
+  // client.driver is a raw pointer deleted under this same lock, so dropping it
+  // here would race a concurrent shutdown. The driver no longer allocates on
+  // this path, so the hold is now a bounded frame copy rather than an
+  // unbounded trip through the allocator.
   client.driver->SubmitFrame(samples_ptr);
   return true;
 }

--- a/thirdparty/rexglue-sdk/src/native/audio/audio_trace.cpp
+++ b/thirdparty/rexglue-sdk/src/native/audio/audio_trace.cpp
@@ -6,6 +6,10 @@
 #include <chrono>
 
 #include <native/audio/audio_trace.h>
+#include <rex/cvar.h>
+
+REXCVAR_DECLARE(bool, audio_trace_telemetry);
+REXCVAR_DECLARE(bool, audio_deep_trace);
 
 namespace rex::audio {
 
@@ -28,6 +32,13 @@ void AudioTraceBuffer::Record(const AudioTraceSubsystem subsystem,
                               const AudioTraceEventType event_type, const uint32_t client_id,
                               const uint32_t value_0, const uint32_t value_1,
                               const uint32_t value_2) {
+  // Reached from the host audio callback on every consumed frame. Taking a
+  // mutex and churning a deque there costs realtime headroom for data nobody
+  // reads unless tracing is on.
+  if (!REXCVAR_GET(audio_trace_telemetry) && !REXCVAR_GET(audio_deep_trace)) {
+    return;
+  }
+
   std::lock_guard<std::mutex> lock(mutex_);
   if (events_.size() >= kMaximumTraceEventCount) {
     events_.pop_front();

--- a/thirdparty/rexglue-sdk/src/native/audio/sdl/sdl_audio_driver.cpp
+++ b/thirdparty/rexglue-sdk/src/native/audio/sdl/sdl_audio_driver.cpp
@@ -69,9 +69,69 @@ bool SdlAudioDriver::Initialize() {
     return false;
   }
 
-  REXAPU_INFO("SdlAudioDriver initialized: client={} channels={} freq={}", client_index_,
-              kOutputChannels, kAudioFrameSampleRate);
+  // Size the queue from the period SDL actually opened, not an assumption. SDL
+  // defaults to 1024 frames at 48kHz, which is four 256-sample guest frames;
+  // the old hardcoded target of 3 could never fill one callback.
+  SDL_AudioSpec device_spec{};
+  int device_sample_frames = 0;
+  if (SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(stream_), &device_spec,
+                               &device_sample_frames) &&
+      device_sample_frames > 0) {
+    device_buffer_frames_.store(static_cast<uint32_t>(device_sample_frames),
+                                std::memory_order_release);
+  } else {
+    REXAPU_WARN("SdlAudioDriver could not query the device period for client {} ({}); "
+                "assuming {} frames",
+                client_index_, SDL_GetError(),
+                device_buffer_frames_.load(std::memory_order_acquire));
+  }
+
+  {
+    const size_t pool_frames = static_cast<size_t>(queue_target_frames()) * 2 + 4;
+    std::lock_guard<std::mutex> guard(frames_mutex_);
+    frame_pool_storage_.assign(pool_frames * kAudioFrameTotalSamples, 0.0f);
+    for (size_t i = 0; i < pool_frames; ++i) {
+      frames_unused_.push(frame_pool_storage_.data() + (i * kAudioFrameTotalSamples));
+    }
+  }
+
+  const char* driver_name = SDL_GetCurrentAudioDriver();
+  REXAPU_INFO("SdlAudioDriver initialized: client={} backend={} channels={} freq={} "
+              "device_period_frames={} queue_target={} queue_low_water={}",
+              client_index_, driver_name ? driver_name : "?", kOutputChannels,
+              kAudioFrameSampleRate, device_buffer_frames_.load(std::memory_order_acquire),
+              queue_target_frames(), queue_low_water_frames());
   return true;
+}
+
+uint32_t SdlAudioDriver::queue_target_frames() const {
+  return RequiredQueueFramesForDevice(device_buffer_frames_.load(std::memory_order_acquire),
+                                      kQueueHeadroomFrames);
+}
+
+uint32_t SdlAudioDriver::queue_low_water_frames() const {
+  return std::max(1u, queue_target_frames() - 1);
+}
+
+// Caller must hold frames_mutex_. Never allocates: on pool exhaustion the
+// oldest queued frame is recycled, dropping the stalest audio rather than
+// blocking the realtime callback behind the allocator.
+float* SdlAudioDriver::AcquireFrameBufferLocked() {
+  if (!frames_unused_.empty()) {
+    float* buffer = frames_unused_.top();
+    frames_unused_.pop();
+    return buffer;
+  }
+
+  if (!frames_queued_.empty()) {
+    float* buffer = frames_queued_.front();
+    frames_queued_.pop();
+    queued_depth_.fetch_sub(1, std::memory_order_relaxed);
+    dropped_frames_.fetch_add(1, std::memory_order_relaxed);
+    return buffer;
+  }
+
+  return nullptr;
 }
 
 void SdlAudioDriver::Shutdown() {
@@ -86,14 +146,16 @@ void SdlAudioDriver::Shutdown() {
   }
 
   std::lock_guard<std::mutex> guard(frames_mutex_);
+  // The frames point into frame_pool_storage_, so they are released with it.
   while (!frames_unused_.empty()) {
-    delete[] frames_unused_.top();
     frames_unused_.pop();
   }
   while (!frames_queued_.empty()) {
-    delete[] frames_queued_.front();
     frames_queued_.pop();
   }
+  frame_pool_storage_.clear();
+  frame_pool_storage_.shrink_to_fit();
+  queued_depth_.store(0, std::memory_order_relaxed);
   pending_output_float_count_ = 0;
   pending_output_float_offset_ = 0;
 
@@ -113,12 +175,10 @@ void SdlAudioDriver::SubmitFrame(const uint32_t frame_ptr) {
   float* output_frame = nullptr;
   {
     std::lock_guard<std::mutex> guard(frames_mutex_);
-    if (frames_unused_.empty()) {
-      output_frame = new float[kAudioFrameTotalSamples];
-    } else {
-      output_frame = frames_unused_.top();
-      frames_unused_.pop();
-    }
+    output_frame = AcquireFrameBufferLocked();
+  }
+  if (!output_frame) {
+    return;
   }
 
   std::memcpy(output_frame, input_frame, sizeof(float) * kAudioFrameTotalSamples);
@@ -153,12 +213,10 @@ void SdlAudioDriver::SubmitSilenceFrame() {
   float* output_frame = nullptr;
   {
     std::lock_guard<std::mutex> guard(frames_mutex_);
-    if (frames_unused_.empty()) {
-      output_frame = new float[kAudioFrameTotalSamples];
-    } else {
-      output_frame = frames_unused_.top();
-      frames_unused_.pop();
-    }
+    output_frame = AcquireFrameBufferLocked();
+  }
+  if (!output_frame) {
+    return;
   }
 
   std::fill_n(output_frame, kAudioFrameTotalSamples, 0.0f);
@@ -195,6 +253,7 @@ AudioDriverTelemetry SdlAudioDriver::GetTelemetry() const {
       silence_injections_.load(std::memory_order_relaxed),
       queued_depth_.load(std::memory_order_relaxed),
       peak_queued_depth_.load(std::memory_order_relaxed),
+      dropped_frames_.load(std::memory_order_relaxed),
   };
 }
 
@@ -240,17 +299,29 @@ void SdlAudioDriver::FillStream(SDL_AudioStream* stream, int bytes_needed) {
     }
 
     if (pending_output_float_count_ == 0) {
-      std::array<float, kRenderDriverTicSamplesPerFrame * kOutputChannels> silence{};
-      if (!SDL_PutAudioStreamData(stream, silence.data(), kOutputFrameBytes)) {
+      // Write only what was actually asked for, and report only what was
+      // actually written. The guest render-driver tic is derived entirely from
+      // ReportSamplesConsumedForClient, so over-reporting here runs the guest's
+      // audio clock ahead of real playback.
+      const std::array<float, kRenderDriverTicSamplesPerFrame * kOutputChannels> silence{};
+      const int silence_bytes = std::min(bytes_needed, kOutputFrameBytes);
+      if (silence_bytes <= 0) {
+        break;
+      }
+      if (!SDL_PutAudioStreamData(stream, silence.data(), silence_bytes)) {
         return;
       }
       ++underrun_count_;
       ++silence_injections_;
-      bytes_needed -= std::min(bytes_needed, kOutputFrameBytes);
-      
-      consumed_frames_.fetch_add(1, std::memory_order_relaxed);
+      bytes_needed -= silence_bytes;
+
+      const uint32_t silence_samples =
+          static_cast<uint32_t>(silence_bytes / (kOutputChannels * sizeof(float)));
+      if (silence_bytes == kOutputFrameBytes) {
+        consumed_frames_.fetch_add(1, std::memory_order_relaxed);
+      }
       if (runtime_) {
-        runtime_->ReportSamplesConsumedForClient(client_index_, kRenderDriverTicSamplesPerFrame);
+        runtime_->ReportSamplesConsumedForClient(client_index_, silence_samples);
         runtime_->WakeWorker();
       }
       continue;

--- a/thirdparty/rexglue-sdk/src/native/audio/wasapi/wasapi_audio_driver.cpp
+++ b/thirdparty/rexglue-sdk/src/native/audio/wasapi/wasapi_audio_driver.cpp
@@ -46,12 +46,6 @@ uint32_t ClampRequestedFrames() {
   return static_cast<uint32_t>(std::clamp(REXCVAR_GET(audio_wasapi_buffer_frames), 64, 2048));
 }
 
-uint32_t RequiredQueueFramesForDevice(const uint32_t device_buffer_frames) {
-  const uint32_t buffer_frames = std::max(device_buffer_frames, 1u);
-  return std::max(3u, (buffer_frames + kRenderDriverTicSamplesPerFrame - 1) /
-                           kRenderDriverTicSamplesPerFrame);
-}
-
 REFERENCE_TIME FramesToHundredsOfNanoseconds(const uint32_t frame_count,
                                              const uint32_t sample_rate) {
   return static_cast<REFERENCE_TIME>((10000000ull * frame_count) / sample_rate);

--- a/thirdparty/rexglue-sdk/src/native/ui/renderdoc_api.cpp
+++ b/thirdparty/rexglue-sdk/src/native/ui/renderdoc_api.cpp
@@ -20,7 +20,12 @@ std::unique_ptr<RenderDocAPI> RenderDocAPI::CreateIfConnected() {
 
   pRENDERDOC_GetAPI get_api = nullptr;
 
-  if (!renderdoc_api->library_.Load(platform::lib_names::kRenderDoc)) {
+  // Must not LOAD RenderDoc - only notice one that has injected itself. On
+  // Linux librenderdoc.so sits in a system library directory whenever
+  // RenderDoc is installed, so a plain dlopen here pulled it into every run,
+  // which is what put its overlay on the swapchain (and silently turned
+  // gpu_debug_markers on via IsGpuDebugMarkersEnabled).
+  if (!renderdoc_api->library_.LoadIfAlreadyLoaded(platform::lib_names::kRenderDoc)) {
     return nullptr;
   }
   get_api = renderdoc_api->library_.GetSymbol<pRENDERDOC_GetAPI>("RENDERDOC_GetAPI");

--- a/thirdparty/rexglue-sdk/src/system/diag_crash_handler.cpp
+++ b/thirdparty/rexglue-sdk/src/system/diag_crash_handler.cpp
@@ -701,15 +701,160 @@ void NotifyOrderlyShutdown() {
 
 #else  // !REX_PLATFORM_WIN32
 
-// POSIX: not implemented yet. The seam is this file - a signal-based
-// implementation (SIGSEGV/SIGABRT + sigaltstack) drops in behind the same
-// header; the guest side (PPCContext + backchain) is already
-// platform-neutral.
+// POSIX: reports the guest side of a fault.
+//
+// ExceptionHandler owns SIGSEGV here (it drives the MMIO and write-watch
+// paths), so rather than installing a competing signal handler this registers
+// an unhandled-fault reporter with it. What it prints is the part a host stack
+// trace cannot give: which guest function faulted, and the guest call chain
+// that led there.
+//
+// Everything below runs on a thread that is about to die, so it takes no locks
+// and probes every guest read before performing it.
+
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <rex/exception_handler.h>
+#include <rex/memory.h>
+#include <rex/ppc/context.h>
+#include <rex/system/thread_state.h>
 
 namespace rex::diag::crash {
 
-void Install(const InstallOptions&) {}
-void SetGuestMemoryBounds(const void*, uint64_t) {}
+namespace {
+
+constexpr uint32_t kGuestVirtualBase = 0x100000000u;
+constexpr int kMaxGuestFrames = 32;
+
+std::atomic<uintptr_t> g_guest_base{0};
+std::atomic<uint64_t> g_guest_extent{0};
+
+// Reads one big-endian guest u32 without faulting.
+//
+// Checking the page protection first is not sufficient: guest memory is a shm
+// mapping, so a page can be readable and still have no backing behind it, and
+// touching one of those raises SIGBUS - for which no handler is installed, so
+// it kills the process. That turns this reporter into the thing that destroys
+// the crash it was invoked to describe.
+//
+// process_vm_readv performs the access in the kernel and reports EFAULT rather
+// than signalling, which is exactly the semantics a crash-time reader needs.
+bool SafeReadGuestU32(uint32_t guest_address, uint32_t* out) {
+  uintptr_t base = g_guest_base.load(std::memory_order_relaxed);
+  uint64_t extent = g_guest_extent.load(std::memory_order_relaxed);
+  if (!base || uint64_t(guest_address) + 4ull > extent) {
+    return false;
+  }
+  uint32_t value = 0;
+  iovec local{&value, sizeof(value)};
+  iovec remote{reinterpret_cast<void*>(base + guest_address), sizeof(value)};
+  if (process_vm_readv(getpid(), &local, 1, &remote, 1, 0) != ssize_t(sizeof(value))) {
+    return false;
+  }
+  *out = __builtin_bswap32(value);
+  return true;
+}
+
+void ReportGuestState(uint64_t fault_address, uint64_t host_pc, bool is_write) {
+  auto* thread_state = rex::runtime::ThreadState::Get();
+  PPCContext* ctx = thread_state ? thread_state->context() : nullptr;
+  if (!ctx) {
+    REXLOG_ERROR("[FAULT] no guest context on this thread - the fault is in host code");
+    return;
+  }
+
+  if (fault_address >= kGuestVirtualBase) {
+    REXLOG_ERROR("[FAULT] guest {} of {:#010x}; host pc {:#x}", is_write ? "write" : "read",
+                 uint32_t(fault_address - kGuestVirtualBase), host_pc);
+  }
+
+  // The guest call chain. Each frame's saved lr is the return address into its
+  // caller, so these are the guest functions that led to the fault.
+  REXLOG_ERROR("[FAULT] guest call chain (lr {:08X}, sp {:08X}):", uint32_t(ctx->lr),
+               uint32_t(ctx->r1.u32));
+  uint32_t sp = ctx->r1.u32;
+  for (int frame = 0; frame < kMaxGuestFrames; ++frame) {
+    uint32_t caller_sp = 0;
+    if (!SafeReadGuestU32(sp, &caller_sp) || caller_sp <= sp) {
+      REXLOG_ERROR("[FAULT]   (chain ends at sp {:08X})", sp);
+      break;
+    }
+    uint32_t saved_lr = 0;
+    if (SafeReadGuestU32(caller_sp - 8, &saved_lr) && saved_lr) {
+      REXLOG_ERROR("[FAULT]   sp {:08X}  return {:08X}", caller_sp, saved_lr);
+    }
+    sp = caller_sp;
+  }
+
+  // Registers, so the faulting pointer can be traced back to what produced it.
+  const PPCRegister* gprs[32] = {
+      &ctx->r0,  &ctx->r1,  &ctx->r2,  &ctx->r3,  &ctx->r4,  &ctx->r5,  &ctx->r6,  &ctx->r7,
+      &ctx->r8,  &ctx->r9,  &ctx->r10, &ctx->r11, &ctx->r12, &ctx->r13, &ctx->r14, &ctx->r15,
+      &ctx->r16, &ctx->r17, &ctx->r18, &ctx->r19, &ctx->r20, &ctx->r21, &ctx->r22, &ctx->r23,
+      &ctx->r24, &ctx->r25, &ctx->r26, &ctx->r27, &ctx->r28, &ctx->r29, &ctx->r30, &ctx->r31};
+  for (int i = 0; i < 32; i += 4) {
+    REXLOG_ERROR("[FAULT]   r{:<2}={:08X}  r{:<2}={:08X}  r{:<2}={:08X}  r{:<2}={:08X}", i,
+                 uint32_t(gprs[i]->u32), i + 1, uint32_t(gprs[i + 1]->u32), i + 2,
+                 uint32_t(gprs[i + 2]->u32), i + 3, uint32_t(gprs[i + 3]->u32));
+  }
+
+  // Memory behind every register that looks like a live guest pointer. A fault
+  // like "walked a list shorter than its own count" is only explicable from the
+  // structures involved, and recovering those one address at a time over gdb
+  // costs a restart per question.
+  REXLOG_ERROR("[FAULT] memory behind pointer-like registers:");
+  uint32_t already_dumped[32] = {};
+  int dumped_count = 0;
+  for (int i = 0; i < 32; ++i) {
+    const uint32_t value = gprs[i]->u32;
+    // Guest heap/data lives well above the null guard; anything tiny is a
+    // count or a flag, not an address.
+    if (value < 0x10000u) {
+      continue;
+    }
+    uint32_t probe = 0;
+    if (!SafeReadGuestU32(value, &probe)) {
+      continue;
+    }
+    // Registers frequently alias (a struct and a field 4 bytes into it); one
+    // dump per 32-byte neighbourhood is enough.
+    bool seen = false;
+    for (int j = 0; j < dumped_count; ++j) {
+      if ((already_dumped[j] & ~31u) == (value & ~31u)) {
+        seen = true;
+        break;
+      }
+    }
+    if (seen) {
+      continue;
+    }
+    already_dumped[dumped_count++] = value;
+
+    uint32_t words[8] = {};
+    int read = 0;
+    for (; read < 8; ++read) {
+      if (!SafeReadGuestU32(value + uint32_t(read * 4), &words[read])) {
+        break;
+      }
+    }
+    REXLOG_ERROR("[FAULT]   r{:<2} -> [{:08X}] {:08X} {:08X} {:08X} {:08X} {:08X} {:08X} {:08X} {:08X}",
+                 i, value, words[0], words[1], words[2], words[3], words[4], words[5], words[6],
+                 words[7]);
+  }
+}
+
+}  // namespace
+
+void Install(const InstallOptions&) {
+  rex::arch::ExceptionHandler::SetUnhandledReporter(&ReportGuestState);
+}
+
+void SetGuestMemoryBounds(const void* host_base, uint64_t extent_bytes) {
+  g_guest_base.store(reinterpret_cast<uintptr_t>(host_base), std::memory_order_relaxed);
+  g_guest_extent.store(extent_bytes, std::memory_order_relaxed);
+}
+
 void SetGuestFunctionTable(const PPCFuncMapping*) {}
 void SetLogTailSink(rex::LogCaptureSink*) {}
 void SetContextProvider(ContextProvider) {}

--- a/thirdparty/rexglue-sdk/src/system/xsocket.cpp
+++ b/thirdparty/rexglue-sdk/src/system/xsocket.cpp
@@ -11,6 +11,7 @@
 #include <rex/system/xsocket.h>
 // #include <rex/system/xnet.h>
 
+#include <rex/cvar.h>
 #include <rex/net/socket.h>
 
 // Standard socket types used by Xbox API emulation
@@ -24,6 +25,15 @@
 #include <netinet/ip.h>
 #include <sys/socket.h>
 #endif
+
+// XNet is not implemented (see SendTo/RecvFrom), so nothing can ever deliver to
+// a guest socket and a blocking recv on one waits forever - the title does not
+// get past its network init without this. Applies to every guest socket, not
+// just VDP: scoping it to VDP alone is not enough to boot. Non-zero bounds the
+// wait, at the cost of making a socket the guest expects to block return
+// EAGAIN instead, so it must go once XNet exists.
+REXCVAR_DEFINE_UINT32(guest_socket_recv_timeout_us, 2000, "Network",
+                      "Receive timeout in microseconds for guest sockets (0 = block indefinitely)");
 
 namespace rex::system {
 
@@ -50,6 +60,16 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
   if (native_handle_ == -1) {
     return X_STATUS_UNSUCCESSFUL;
   }
+
+#if !REX_PLATFORM_WIN32
+  const uint32_t recv_timeout_us = REXCVAR_GET(guest_socket_recv_timeout_us);
+  if (recv_timeout_us) {
+    struct timeval tv;
+    tv.tv_sec = recv_timeout_us / 1000000;
+    tv.tv_usec = recv_timeout_us % 1000000;
+    setsockopt(native_handle_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  }
+#endif
 
   return X_STATUS_SUCCESS;
 }

--- a/thirdparty/rexglue-sdk/tests/unit/CMakeLists.txt
+++ b/thirdparty/rexglue-sdk/tests/unit/CMakeLists.txt
@@ -39,3 +39,29 @@ catch_discover_tests(unit_tests
         LABELS "unit"
         TIMEOUT 60
 )
+
+# Host wait-primitive semantics. Kept as its own binary because it needs only
+# rexcore, so it stays runnable even when the wider unit_tests link is broken.
+add_executable(sync_tests
+    core/sync_semantics_test.cpp
+)
+
+target_include_directories(sync_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(sync_tests PRIVATE
+    rexcore
+    Catch2::Catch2WithMain
+)
+
+set_target_properties(sync_tests PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests/bin
+)
+
+catch_discover_tests(sync_tests
+    TEST_PREFIX "sync."
+    PROPERTIES
+        LABELS "unit"
+        TIMEOUT 120
+)

--- a/thirdparty/rexglue-sdk/tests/unit/core/sync_semantics_test.cpp
+++ b/thirdparty/rexglue-sdk/tests/unit/core/sync_semantics_test.cpp
@@ -1,0 +1,234 @@
+/**
+ * @file        tests/unit/core/sync_semantics_test.cpp
+ * @brief       Windows-dispatcher semantics for the host wait primitives
+ *
+ * @copyright   Copyright (c) 2026 Tom Clay <tomc@tctechstuff.com>
+ *              All rights reserved.
+ *
+ * @license     BSD 3-Clause License
+ *              See LICENSE file in the project root for full license text.
+ */
+
+// These tests encode behaviour that the Win32 dispatcher guarantees. The Win32
+// backend delegates to the OS and so inherits it for free, which makes Windows
+// the oracle: every test here must pass there unchanged. They exist because the
+// POSIX backend reimplements the primitives by hand, and a guest race that is
+// benign under Windows semantics turns into a permanent hang under different
+// ones.
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <native/thread.h>
+
+using namespace std::chrono_literals;
+using rex::thread::Event;
+using rex::thread::WaitResult;
+
+namespace {
+
+// Long enough that a correct implementation never trips it, short enough that a
+// broken one fails the suite instead of hanging it.
+constexpr auto kGenerous = 2000ms;
+
+// Give a spawned thread time to actually reach its Wait before we signal.
+void SettleUntilWaiting() { std::this_thread::sleep_for(50ms); }
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Auto-reset events count releases, they are not a boolean
+// ---------------------------------------------------------------------------
+//
+// This is the AC6 hang in miniature. Two threads are parked on one auto-reset
+// event and it is signalled twice. On Windows each SetEvent releases one
+// waiter, so both run. An implementation that models the event as a single
+// bool collapses the two signals into one and strands a waiter forever.
+TEST_CASE("auto-reset event releases one waiter per Set", "[sync]") {
+  for (int trial = 0; trial < 20; ++trial) {
+    auto event = Event::CreateAutoResetEvent(false);
+    std::atomic<int> released{0};
+
+    std::vector<std::thread> waiters;
+    for (int i = 0; i < 2; ++i) {
+      waiters.emplace_back([&] {
+        if (rex::thread::Wait(event.get(), false, kGenerous) == WaitResult::kSuccess) {
+          released.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+    SettleUntilWaiting();
+
+    // Back-to-back, so both land before either waiter can consume one.
+    event->Set();
+    event->Set();
+
+    for (auto& t : waiters) {
+      t.join();
+    }
+    INFO("trial " << trial);
+    REQUIRE(released.load() == 2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Waiters are released in arrival order
+// ---------------------------------------------------------------------------
+//
+// Windows dispatcher objects release waiters FIFO (within a priority). Without
+// an ordering guarantee a thread can lose every race indefinitely, which is
+// starvation rather than a deadlock but is just as fatal to a guest that is
+// waiting on a condition another thread already satisfied.
+TEST_CASE("auto-reset event releases waiters in FIFO order", "[sync]") {
+  constexpr int kTrials = 20;
+  int first_waiter_won = 0;
+
+  for (int trial = 0; trial < kTrials; ++trial) {
+    auto event = Event::CreateAutoResetEvent(false);
+    std::atomic<int> winner{-1};
+
+    std::thread a([&] {
+      if (rex::thread::Wait(event.get(), false, kGenerous) == WaitResult::kSuccess) {
+        int expected = -1;
+        winner.compare_exchange_strong(expected, 0);
+      }
+    });
+    SettleUntilWaiting();  // a is queued first
+
+    std::thread b([&] {
+      if (rex::thread::Wait(event.get(), false, kGenerous) == WaitResult::kSuccess) {
+        int expected = -1;
+        winner.compare_exchange_strong(expected, 1);
+      }
+    });
+    SettleUntilWaiting();
+
+    event->Set();   // must release 'a'
+    SettleUntilWaiting();
+    event->Set();   // release the other so the trial can finish
+
+    a.join();
+    b.join();
+    if (winner.load() == 0) {
+      ++first_waiter_won;
+    }
+  }
+
+  INFO("first-arrived waiter won " << first_waiter_won << " of " << kTrials << " trials");
+  REQUIRE(first_waiter_won == kTrials);
+}
+
+// ---------------------------------------------------------------------------
+// SignalAndWait must not lose a signal delivered in the release/wait window
+// ---------------------------------------------------------------------------
+//
+// SignalObjectAndWait exists so a thread can release a lock and enqueue on a
+// condition atomically - the release-and-wait at the heart of every hand-rolled
+// condition variable, including the one AC6 uses. Implemented as a separate
+// Signal() then Wait(), another thread can take the lock and signal the
+// condition in the gap. With more than one waiter that signal can be consumed
+// by somebody else, and the caller sleeps forever on a condition that is
+// already true.
+TEST_CASE("SignalAndWait does not lose a wakeup to the release window", "[sync]") {
+  for (int trial = 0; trial < 20; ++trial) {
+    auto lock_event = Event::CreateAutoResetEvent(true);    // mutex: signalled == available
+    auto cond_event = Event::CreateAutoResetEvent(false);   // condition
+    std::atomic<int> released{0};
+
+    std::vector<std::thread> waiters;
+    for (int i = 0; i < 2; ++i) {
+      waiters.emplace_back([&] {
+        // Acquire the "mutex", then atomically release it and wait.
+        REQUIRE(rex::thread::Wait(lock_event.get(), false, kGenerous) == WaitResult::kSuccess);
+        if (rex::thread::SignalAndWait(lock_event.get(), cond_event.get(), false, kGenerous) ==
+            WaitResult::kSuccess) {
+          released.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+    SettleUntilWaiting();
+
+    // One notification per waiter, from a thread that also takes the lock -
+    // exactly the setter side of the guest's condition variable.
+    for (int i = 0; i < 2; ++i) {
+      REQUIRE(rex::thread::Wait(lock_event.get(), false, kGenerous) == WaitResult::kSuccess);
+      lock_event->Set();
+      cond_event->Set();
+      std::this_thread::sleep_for(10ms);
+    }
+
+    for (auto& t : waiters) {
+      t.join();
+    }
+    INFO("trial " << trial);
+    REQUIRE(released.load() == 2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Regression guards for the rewrite - these should pass before and after
+// ---------------------------------------------------------------------------
+
+TEST_CASE("manual-reset event releases every waiter", "[sync]") {
+  auto event = Event::CreateManualResetEvent(false);
+  std::atomic<int> released{0};
+
+  std::vector<std::thread> waiters;
+  for (int i = 0; i < 4; ++i) {
+    waiters.emplace_back([&] {
+      if (rex::thread::Wait(event.get(), false, kGenerous) == WaitResult::kSuccess) {
+        released.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+  SettleUntilWaiting();
+
+  event->Set();  // one Set, all four go
+
+  for (auto& t : waiters) {
+    t.join();
+  }
+  REQUIRE(released.load() == 4);
+}
+
+TEST_CASE("auto-reset event retains a signal with no waiter present", "[sync]") {
+  auto event = Event::CreateAutoResetEvent(false);
+  event->Set();
+  // Already signalled: this must return immediately and consume the signal.
+  REQUIRE(rex::thread::Wait(event.get(), false, kGenerous) == WaitResult::kSuccess);
+  // Consumed: the next wait must time out rather than succeed.
+  REQUIRE(rex::thread::Wait(event.get(), false, 100ms) == WaitResult::kTimeout);
+}
+
+TEST_CASE("wait times out when never signalled", "[sync]") {
+  auto event = Event::CreateAutoResetEvent(false);
+  REQUIRE(rex::thread::Wait(event.get(), false, 100ms) == WaitResult::kTimeout);
+}
+
+TEST_CASE("WaitMultiple wait-any returns the signalled index", "[sync]") {
+  auto a = Event::CreateAutoResetEvent(false);
+  auto b = Event::CreateAutoResetEvent(false);
+  rex::thread::WaitHandle* handles[] = {a.get(), b.get()};
+
+  b->Set();
+  auto result = rex::thread::WaitAny(handles, 2, false, kGenerous);
+  REQUIRE(result.first == WaitResult::kSuccess);
+  REQUIRE(result.second == 1);
+}
+
+TEST_CASE("WaitMultiple wait-all requires every object", "[sync]") {
+  auto a = Event::CreateAutoResetEvent(false);
+  auto b = Event::CreateAutoResetEvent(false);
+  rex::thread::WaitHandle* handles[] = {a.get(), b.get()};
+
+  a->Set();
+  REQUIRE(rex::thread::WaitAll(handles, 2, false, 100ms) == WaitResult::kTimeout);
+
+  a->Set();
+  b->Set();
+  REQUIRE(rex::thread::WaitAll(handles, 2, false, kGenerous) == WaitResult::kSuccess);
+}


### PR DESCRIPTION
This is a fork with most fixes and enhancements from master working on linux.
Closes #4, closes #6, closes #12
I've tested this as far as the end of Mission 1 so far, with everything working as expected so far.
Note: Heavily vibecoded, so some of the code is going to be less pretty than it should be.

First, a list of the features I have not yet ported, with no immediate plan due to the amount of effort needed to make them work on linux:
1. Texture replacement modding
2. KBM support
3. Networking (not sure how much AC6 makes use of that).

Also, I did **NOT** test this on windows. Someone with a windows machine should definitely give this a run before anyone thinks about merging this.

Now, an AI-gen'd list of changes for the main build system and OS-dependent code:

### 1. Build the Vulkan backend and the AC6 backend fixes on Linux

`ac6_widescreen.cpp` and `ac6_fullres_effects.cpp` were Win32-only — `__try`/`__except`,
`VirtualQuery`/`VirtualProtect`, `_byteswap_*`, `CreateThread`. The platform-independent logic
(the camera signature predicate, the aspect poke, the static-default patch) is now factored out and
shared, with only the memory-probing primitives behind the platform split.

`CMakeLists.txt` moves the texture-swap cvar definitions into `src/ac6_texture_swap_cvars.cpp` so
they exist on every platform while `ac6_texture_overrides.cpp` — which needs the D3D12/DXGI format
enums — stays Windows-only, and declares the `rexsystem` → `rexgraphics` link back-edge that a
Vulkan-only build needs (on Windows the symbol resolves by accident through an earlier reference).

### 2. Guest-memory probing that cannot fault

Guest memory is an shm mapping, so a page can be readable and still unbacked: a plain dereference
raises **SIGBUS**, for which no handler is installed. Every probing read now goes through
`process_vm_readv`, which performs the access in the kernel and reports `EFAULT` instead of
signalling. Writes stay direct (after a probing read validates the mapping) so a write to a
GPU-write-watched page still faults into the SDK's recovery handler and is tracked like any other
guest write.

The widescreen memory sweep has no `VirtualQuery` to walk regions with, and parsing
`/proc/self/maps` per sweep is far too slow, so it strides the guest range in 1 MiB chunks read
through the same call — an unmapped range simply fails — and scans the copy, taking writability
from the SDK's own page tracking.

### 3. `QueryProtect` protection shadow

`QueryProtect` answered by parsing `/proc/self/maps`: a file open plus a ~1000-line scan. The MMIO
handler calls it on **every** access violation, while holding the global critical region, and guest
write-watches fault constantly — this measured at **39% of total process CPU** with the guest making
no forward progress at all. Windows has no equivalent problem, `VirtualQuery` being a cheap syscall.

`AllocFixed`, `Protect` and `DeallocFixed` are the only writers of this process's own protections,
so they now record them in a coalesced, page-aligned range map answered in O(1). A lookup that
misses still falls back to the maps file, so addresses this module never handed out (host
allocations, the stack) answer exactly as before.

### 4. NT event semantics for POSIX waits

The Win32 dispatcher hands an auto-reset release to one specific waiter, in FIFO order. Publishing a
flag that every waiter races for is not equivalent in two ways that both strand the guest: two
releases delivered before any waiter runs collapse into one, and no waiter is guaranteed to ever
win. Signallers now grant a token to the longest-waiting thread instead
(`posix_event_fifo_handoff`, on by default — off restores the old flag behaviour so a suspected
regression can be A/B'd without a rebuild).

Alongside it: a `log_long_waits_ms` watchdog that names the stuck thread, the object and the wait
kind from a fixed-address table readable out of a core or a live process, and a `sync_tests` binary
covering the primitives (kept separate from `unit_tests` so it needs only `rexcore`). The watchdog
logs at error level, because `ac6_performance_mode` pins the log level to error and that is exactly
the configuration a hang gets reproduced in.

### 5. POSIX file handles

`O_RDONLY`/`O_WRONLY`/`O_RDWR` are an enumeration in the low two bits (0/1/2), not bit flags, so
they cannot be OR-ed together: a read+write open OR-ed to `O_WRONLY` and every read on that
descriptor then failed with `EBADF`. The title opens its save read+write, so the reads silently
returned nothing and it wrote back whatever its buffer already held. Windows has no equivalent
problem — `GENERIC_READ|GENERIC_WRITE` really are bit flags.

Also: `pread`/`pwrite` returning `-1` was assigned straight into a `size_t` out-parameter, reporting
`SIZE_MAX` bytes transferred to any caller that checked the count rather than the bool.

### 6. Crash and fault diagnostics

An unclaimed `SIGSEGV` returned from the handler, which re-executes the faulting instruction, which
faults again — the thread spins inside the signal handler forever, burning a core, with no
diagnostic anywhere. A guest null dereference therefore appeared as an unexplained "deadlock"
instead of a crash. It is now reported (translated back to a guest address), handed to a
guest-aware reporter, and then allowed to die under `SIG_DFL`, producing a core that points at the
real faulting instruction.

`diag_crash_handler.cpp` gains its POSIX half. Rather than installing a competing `SIGSEGV`
handler — `ExceptionHandler` owns that signal — it registers as that reporter and prints what a
host backtrace cannot give: the guest call chain walked from the saved stack backchain, all 32
GPRs, and the memory behind every register that looks like a live guest pointer. It runs on a
thread that is about to die, so it takes no locks and probes every read first.

### 7. Guest sockets no longer block forever

XNet is not implemented, so nothing can ever deliver to a guest socket and a blocking `recv` on one
waits forever — the title does not get past its network init. `guest_socket_recv_timeout_us`
(2 ms default) bounds the wait. This is a stopgap: it makes a socket the guest expects to block
return `EAGAIN` instead, and should be removed if real Xbox 360 socket semantics land.

### 8. We were injecting RenderDoc into ourselves

`RenderDocAPI::CreateIfConnected()` is meant to hand back the API *only* when RenderDoc has already
attached. On POSIX it probed with a plain `dlopen("librenderdoc.so", RTLD_LAZY)`, which **loads**
the library when it is not already mapped. `librenderdoc.so` lives in a system library directory on
any machine with RenderDoc installed, so every run pulled RenderDoc in, initialised it, and got its
capture overlay drawn over the game — and, through `IsGpuDebugMarkersEnabled()`'s "auto-enable when
RenderDoc is detected" path, silently turned `gpu_debug_markers` on as well.

Windows has the same shape but not the same outcome: `renderdoc.dll` is not on the default DLL
search path unless RenderDoc genuinely injected it. The probe now uses a new
`DynamicLibrary::LoadIfAlreadyLoaded`, which is `RTLD_NOLOAD` on POSIX and unchanged
`LoadLibraryW` on Windows, so it observes RenderDoc rather than causing it. Launching *under*
RenderDoc still works exactly as before.

---

## Vulkan backend

### 9. AC6's backend hooks were D3D12-only

A whole family of AC6 fixes was wired into the D3D12 command processor only. On Vulkan they
reported themselves enabled in the log and did nothing. Ported:

- **World-compositor draw notification** — the per-frame "3D world is rendering" signal. Without
  it `AreTimingHooksActive()` fails closed forever and the entire FPS-unlock / physics-dt family is
  silently dead.
- **Full-res effects** — the compositor mask crop, and the 2:1 silhouette downscaler fix (the draw
  that produced the 2×2 ghost planes).
- **Ultrawide** — screen-space UI ortho patching in the VS float constants, sub-viewport
  (radar window, PiP inset) viewport *and* scissor shrink about the render-target centre, target
  marker quad narrowing, and the mode-classified swap-source notification that decides fill vs.
  letterbox presentation.
- **HD terrain** — the synthetic vertex-fetch-95 ring table, its residency redirect and its
  fetch-constant patch.
- **Condensation trails** — the physical-memory invalidation callback that drops cached vertex
  buffer residency when the guest rewrites its trail history ring in place, and the forced RT0
  colour mask for the trail point-list pass (whose register state writes no colour components, so
  the draw was dropped entirely).
- **Sun flare** — the second, malformed billboard cull, previously only in the DXBC translator.
- **De-swizzle neutralisation** — the identity host-texel UV for allowlisted post-process passes.

### 10. Texture result exponent bias read from the wrong fetch-constant word

The SPIR-V translator took the result exponent bias from bits 13:18 of fetch constant **word 4**.
Those bits fall inside `lod_bias` (`dword_4 +12`, 10 bits); the actual `exp_adjust` field is at
`dword_3 +13`. A non-zero LOD bias was therefore applied as an exponent bias, scaling every fetched
texel by a power of two — for AC6 by 2⁻⁸, crushing the composite to black. The DXBC translator
reads word 3, which is why this only ever affected Vulkan.

### 11. `execute_unclipped_draw_vs_on_cpu` restored to its upstream default

With it off, unclipped draws get no vertex extent estimate, so `height_used` falls back to the full
render-target height. A single depth-only unclipped draw then claims all 2048 EDRAM tiles and takes
ownership of every range, and anything resolving from those tiles afterwards inherits depth data
instead of colour.

### 12. Diagnostics on the silent failure paths

Several Vulkan paths returned `false` or `continue`d without a word, leaving only a black result to
work back from. Once-only error logs added for: a failed texture upload, a texture with no load
shader or a null load pipeline, a transfer with no buildable pipeline, and a render target that
would transfer to itself. `VulkanPipelineCache` also honours `dump_shaders` now — only the D3D12
pipeline cache dumped its translated binary, so the setting produced no SPIR-V at all.

---

## Audio

### 13. SDL output sized to the real device period

The driver hardcoded a queue target of 3 render-driver frames while SDL opens a 1024-frame period
at 48 kHz — four 256-sample guest frames. The host therefore asked for more audio than the runtime
was ever allowed to queue, and the shortfall was filled with silence on **every** callback.

The period is now queried from the device and the queue target derived from it, with two frames of
headroom for worker wake jitter (the POSIX multi-handle wait is a 1 ms poll, not a real blocking
wait). Supporting changes:

- The frame pool is pre-allocated as one backing store, so the realtime callback never contends
  with a thread inside the allocator; on exhaustion the stalest queued frame is recycled rather
  than blocking, and the drop is counted in telemetry.
- Silence injection writes only what was actually asked for and reports only what it actually
  wrote — the guest render-driver tic is derived entirely from `ReportSamplesConsumedForClient`,
  so over-reporting ran the guest's audio clock ahead of real playback.
- `audio_max_queue_depth` raised to 16, and a clamp below what the driver needs now warns instead
  of silently guaranteeing an underrun.
- A safety valve releases the startup callback pacing after a bounded number of throttled passes,
  so a starved host cannot wedge startup indefinitely.
- `AudioTraceBuffer::Record` early-outs when tracing is off. It is reached from the host audio
  callback on every consumed frame, and took a mutex and churned a deque there for data nobody
  reads.

---

## Input

### 14. Sticks the kernel binds to `hid-generic` were silently invisible

This one is technically an enhancement because I'm not sure how windows handles joystick to gamepad for rexglue.

A Thrustmaster T.Flight Hotas One (USB `044f:b68d`, the AC7-branded flight stick) produced no input at all and, worse, produced no log line either — it was indistinguishable from a device that was never plugged in. Five things had
to line up for that:

The kernel's `xpad` table has no entry for `b68d`, so the stick binds to `hid-generic`. That driver
describes it with **joystick-class** button codes (`BTN_TRIGGER`…) rather than the gamepad-class
codes (`BTN_GAMEPAD`/`BTN_SOUTH`…) an `xpad` device would report. SDL3's Linux backend will
synthesise a gamepad mapping for an unknown device, but `LINUX_JoystickGetGamepadMapping` gives up
immediately on `!has_key[BTN_GAMEPAD]` — "not a gamepad according to the specs". Neither SDL's
built-in mapping table nor the upstream community `SDL_GameControllerDB` has an entry for this GUID.
And `SDLInputDriver` reaches devices exclusively through the SDL *gamepad* API: it inited only
`SDL_INIT_GAMEPAD` and listened only for `SDL_EVENT_GAMEPAD_ADDED`, which an unmapped joystick never
raises. There is no `SDL_Joystick` fallback anywhere in the runtime.

Three changes, only the first of which is device-specific:

- A `gamecontrollerdb.txt` now ships at the repo root and is copied next to the executable on every
  build, carrying a hand-authored entry for this stick. Its throttle is split across both triggers,
  its yaw twist across the shoulder buttons, and its Trim control is an *axis* rather than a pair of
  buttons, so it drives `dpup`/`dpdown` as half-axis bindings. The coolie hat is the right stick,
  which deliberately leaves `dpleft`/`dpright` unbound — AC6 does not need them, at the cost of
  `UpdateXCapabilities` reporting `X_INPUT_CAPS_NO_NAVIGATION`.
- `hid_mappings_file` resolves against the executable directory first, falling back to the CWD.
  Previously it was a bare relative name resolved against the CWD alone, and since no such file
  shipped, that path only ever logged `file '...' does not exist.` Mappings also load *before*
  `SDL_INIT_GAMEPAD` now, so the initial device-added burst is already mapping-aware.
- `SDL_INIT_JOYSTICK` is requested alongside `SDL_INIT_GAMEPAD` purely so unmapped sticks still
  raise `SDL_EVENT_JOYSTICK_ADDED`. A new handler warns with the device name, VID/PID, and the GUID
  a database line has to be keyed on. The next unrecognised device is a log line rather than a
  hardware investigation.

Incidentally fixed in the same file: `OnControllerDeviceAdded`/`Removed` read `event.cdevice.which`,
the *camera* device union member, where they meant `event.gdevice.which`. The two structs are
layout-identical so it worked, but only by accident.

---

Some more fixes were also incorporated and inspired from a [different seemingly WIP fork of this repo targeting linux](https://github.com/Tetragramm/AC6_recomp/tree/linux-port)
A second, independent Linux port exists at
**The four fixes in this section are that fork's work, ported here** — the analysis and
the original implementations are theirs.

### 15. The >1x mosaic, and arming the scaling fixes for `resolution_scale`

*("Fix the >1x mosaic on Vulkan, and arm the scaling fixes for resolution_scale").*

`param_gen_integer_guest_position` and `param_gen_host_subpixel_restore` existed as cvars and were
read by the DXBC translator, but **nothing on the SPIR-V side read them** — so the scaling fixes
were inert on Vulkan and AC6's deferred EDRAM restore / de-swizzle passes scrambled into a mosaic
at any draw scale above 1x. Two halves, both mirroring the DXBC path:

- `StartFragmentShaderInMain` now floors the reverted PsParamGen position to the integer guest-pixel
  index. Reverting the resolution scale leaves a sub-guest-pixel fraction that is only correct for
  shaders feeding PsParamGen straight to a `tfetch`; shaders doing integer pixel-address maths on it
  see a multiplied period in their `frac()`-based bit extraction and scramble the sample coordinate.
- `ProcessTextureFetchInstruction` re-adds the host sub-pixel after the coordinate is normalized, so
  those passes regain full host resolution instead of sampling at guest resolution. It runs before
  the de-swizzle identity override, which overwrites the coordinate outright — the same precedence
  the DXBC translator uses.

Separately, `ApplyAc6FixDefaults` gated the whole family on `draw_resolution_scale_x/y`, but the
combined `resolution_scale` cvar — what the settings menu writes — leaves those at 1. It now asks
`TextureCache::GetConfigDrawResolutionScale` for the effective scale, so the fixes engage for
everyone who scaled that way; the effective scale is also logged on the config support line.

### 16. A POSIX read at end of file must fail

*("Report a POSIX read at end of file as a failure, like the Win32 handle").*

Win32 `ReadFile` reports `ERROR_HANDLE_EOF`, which `HostPathFile` turns into
`X_STATUS_END_OF_FILE`. `pread` just returns 0, which reached the guest as "success, zero bytes,
position unchanged" — a loader reading a file to its end then never terminates. A short or
zero-length write is likewise a failure now, so the atomic-write path cannot commit a truncated
temp over a good file. (This sits on top of our own fix to the same function, item 5.)

### 17. `getCompTexLD` cube face id and negated Z

*("Produce the cube face id and negated Z whenever they are used").*

Two component-mask bugs in the SPIR-V translator's cube coordinate lowering. Negated Z feeds both
the X-major `sc` (component 1) and the Y-major `tc` (component 0), but was only created for
component 1; and the Y-major face `id` was computed inside the `tc` guard, so it went unset whenever
the id was wanted without the coordinate. Wrong cube-map sampling on Vulkan for any shader
requesting only some components.

### 18. Stencil-bit transfers killed no samples

*("Kill stencil-bit transfer samples whose source bit is clear").*

A stencil-bit transfer from a depth/stencil source binds only the stencil texture — the depth is
not needed and deliberately not bound — so neither packing branch ran and `packed` was left unset.
The sample kill is skipped entirely when `packed` is `NoResult`, so every sample kept its bit and
the destination stencil came out `0xFF` everywhere regardless of the source.
